### PR TITLE
Wiki: data-loss bug fixes + LLM-building design (v3)

### DIFF
--- a/docs/plans/2026-06-08-wiki-dataloss-bugfix.md
+++ b/docs/plans/2026-06-08-wiki-dataloss-bugfix.md
@@ -1,0 +1,47 @@
+# Plan — Wiki data-loss bug fixes (glossary-service)
+
+- **Date:** 2026-06-08 · **Branch:** `wiki/llm-building` (first commits, before wiki-LLM feature)
+- **Size:** L · **Workflow:** /loom 12-phase · **Scope:** single service (glossary-service, Go)
+- **Spec ref:** `docs/specs/2026-06-08-wiki-llm-building.md` §5.5 · merge-spec `docs/specs/2026-06-07-entity-resolution-merge.md` AC4
+
+## Goal
+Fix 2 pre-existing data-loss bugs before wiki bodies become valuable products:
+- **Bug 1** — merge silently abandons loser's `wiki_article` when both sides have one (violates merge AC4).
+- **Bug 2** — kind-delete `ON DELETE CASCADE` silently destroys articles+revisions+suggestions.
+
+## Files touched (~6 src + tests)
+1. `internal/migrate/migrate.go` — schema: `superseded_by_entity_id` col + index; FK swap CASCADE→RESTRICT (DO-block + inline `wikiSQL`); `merge_journal.superseded_wiki_article_id`.
+2. `internal/api/merge_handler.go` — `mergeOne` repoint-else-archive + journal; `revertMergeCore` un-archive.
+3. `internal/api/wiki_handler.go` — `getWikiArticle`/`loadWikiArticleDetail` redirect on superseded.
+4. `internal/api/kinds_crud.go` — `deleteKind` explicit article delete + count in 200 response.
+5. `internal/api/outbox.go` — `wiki.deleted` event emit helper.
+6. `internal/api/*_test.go` — DB-integration tests (merge, un-merge, kind-delete).
+
+## Ordered steps (TDD)
+1. **Migration** — add column + index; FK robust swap (DO-block drops any FK on `wiki_articles.entity_id`, ADD `... ON DELETE RESTRICT`; idempotent on re-run); update inline `wikiSQL` CASCADE→RESTRICT for fresh DBs; add `merge_journal.superseded_wiki_article_id`.
+2. **Failing tests first** (TDD red):
+   - `merge` both-have-article → loser article gets `superseded_by_entity_id=winner`, NOT orphaned; winner article untouched.
+   - `getWikiArticle` on a superseded article → resolves to winner's article (AC1.2).
+   - `revertMerge` → `superseded_by_entity_id` cleared, loser live again (AC1.3 round-trip).
+   - `merge` only-loser-has-article → still repoints to winner (AC1.4 unchanged).
+   - `deleteKind` with soft-deleted entity that has an article → article explicitly deleted, count surfaced, `wiki.deleted` emitted, NO silent cascade; FK RESTRICT verified.
+3. **Bug 1 mergeOne** — try repoint (existing `NOT EXISTS`); if 0 rows, archive `UPDATE … SET superseded_by_entity_id=winner WHERE entity_id=loser AND superseded_by_entity_id IS NULL RETURNING article_id`; journal both `repointed_wiki_article_id` + `superseded_wiki_article_id`.
+4. **Bug 1 revertMergeCore** — if `superseded_wiki_article_id` present → `SET superseded_by_entity_id=NULL`. Keep existing repoint-back.
+5. **Bug 1 redirect** — superseded article fetch returns winner's article (200 + `redirected_from`).
+6. **Bug 2 kinds_crud** — before purge: gather + `DELETE wiki_articles WHERE entity_id IN (soft-deleted of kind)` (revisions/suggestions cascade off article_id — intended), emit `wiki.deleted`/article, return `200 {deleted_wiki_articles:N}` (was 204).
+7. **Bug 2 event** — `outbox.go` `wiki.deleted` (payload `{book_id,article_id,entity_id,reason}`); also emit in `deleteWikiArticle`.
+8. **Green** — `go test ./...` in glossary-service.
+
+## Confirm-at-BUILD
+- Exact `wiki_articles_entity_id_fkey` name (use DO-block to be name-agnostic).
+- `outbox.go` `insertEntityOutboxEvent` shape to mirror for `wiki.deleted` (aggregate_type, payload struct).
+- `deleteKind` response 204→200 — verify FE tolerates (QC).
+- `merge_journal` INSERT/SELECT column lists in merge_handler.go (add the new column to both).
+
+## VERIFY (evidence gate)
+Single service (glossary-service only; `wiki.deleted` emitted, no consumer this task) → **no cross-service live-smoke needed**. Evidence = `go test` output for glossary-service api + migrate packages, green, with the new DB-integration tests named.
+
+## Risks
+- `merge_handler.go` is hardened (journal/TOCTOU/chain-guard) — additive changes only; keep the tx + journal symmetry.
+- FK swap on existing prod data: if a current row would violate RESTRICT it won't (RESTRICT only blocks future deletes). Migration is safe.
+- Response shape change on deleteKind — minor; QC checks FE.

--- a/docs/sessions/SESSION_HANDOFF.md
+++ b/docs/sessions/SESSION_HANDOFF.md
@@ -6,6 +6,25 @@
 
 ## ▶ NEXT SESSION — start here
 
+### ▶ WIKI LLM-BUILDING (branch `wiki/llm-building`, off `main`) — 2026-06-08
+
+**State: DESIGN v3 complete (spec + mockup) + 2 pre-existing data-loss bug fixes BUILT & committed** (first commits on the branch, *before* the feature — `/loom` L, **17 tests green on real Postgres**, /review-impl clear).
+
+**Bug fixes (this commit):**
+- **Bug 1** — merge silently abandoned a loser's `wiki_article` when BOTH sides had one (violated merge-spec AC4 "no silent data loss"; composed with Bug 2 into permanent loss). **Fix:** `wiki_articles.superseded_by_entity_id` archive-in-place (revision-preserved) + `getWikiArticle` redirect→winner (`redirected_from`) + `merge_journal.superseded_wiki_article_id` for symmetric un-merge. Bodies NOT auto-merged (deferred to wiki-LLM §5.4).
+- **Bug 2** — kind-delete `ON DELETE CASCADE` silently destroyed articles+revisions+suggestions. **Fix:** entity FK `CASCADE→RESTRICT` + kind-delete deletes articles explicitly + **count in 200** response (was silent 204) + `wiki.deleted` outbox event (both kind-delete & user-delete, atomic in-tx). superseded_by FK `ON DELETE SET NULL` (anti-dangle).
+- Files: `migrate.go` · `merge_handler.go` · `wiki_handler.go` · `kinds_crud.go` · `outbox.go` + tests (`wiki_dataloss_test.go` new, `merge_handler_test.go`/`kind_aliases_test.go`). Plan [`2026-06-08-wiki-dataloss-bugfix.md`](../plans/2026-06-08-wiki-dataloss-bugfix.md).
+- **/review-impl:** 0 HIGH; 1 MED (redirect untested → HTTP test added w/ a **book-service mock harness** — reusable for the LLM feature) + 4 LOW + 1 COSMETIC **all fixed + re-verified**.
+
+**Design (spec v3 [`2026-06-08-wiki-llm-building.md`](../specs/2026-06-08-wiki-llm-building.md) · mockup `-mockup.html`, 5 screens):** wiki = **deferred-sync materialized view** over a versioned knowledge base. Home = **knowledge-service** (Python; glossary stays SSOT front door). LLM contract = **constrained Markdown → IR → deterministic TipTap mapper** (NOT LLM-emits-TipTap). Generate = **bounded multi-pass** (write→deterministic rule-gate→CanonVerifier→1×revise, keep-if-improved). **Change-control:** capture (MVP: `wiki_article_source_usage` + `build_inputs` fingerprint) → defer (DB `wiki_staleness` ledger + sweep, **NOT realtime CDC**) → decide (**user-gated** regen, cost-capped). Locked PO decisions: BookProfile→**move to book-service**; spoiler = capture-horizon + reader-gate; ledger = DB-table+sweep; feedback+eval flywheel in MVP.
+
+**NEXT:** wiki-LLM feature BUILD per spec v3 — **Phase-1 MVP = generation + §5.1 dependency capture**. Prerequisite sub-task: **move BookProfile → book-service** (cross-cutting, touches lore-enrichment — isolate + test first). Then knowledge-service `app/wiki/` module (clone lore-enrichment runner→generate→verify→writeback).
+
+**Deferred (wiki):**
+- **D-WIKI-SEED-ROBUSTNESS** (test-infra, /review-impl COSMETIC-1) — `migrate.Seed` guards on table-empty; on a shared test DB a prior 'unknown' kind makes default-kind seeding skip → merge fixtures lose 'character'. Worked around in the merge fixture (seed-if-missing); root-cause fix = make `migrate.Seed` per-kind idempotent (`ON CONFLICT (code) DO NOTHING`) — separate cleanup task.
+- **D-WIKI-DELETEKIND-CONTRACT** (LOW-4) — kind-delete 204→200 `{deleted_wiki_articles}`; FE `apiJson` tolerates 200+body (verified). Doc only.
+- Design deferrals in spec v3 §11 (BookProfile cross-service home, `compose_cites` first-live smoke, precise KG-edge events, recycle-bin GC must-not-CASCADE).
+
 ### ▶ RAW SEARCH (branch `raw-search/foundation`, off `origin/main`)
 
 **State: Phase-1 + 2 + 3(A,C,D) + P3-EVAL + E5 + E5B + E6 DONE + LIVE-SMOKE PASSED (2026-06-08).** Hybrid (lexical+semantic, RRF) + cross-encoder rerank end-to-end, surfaced in the search UI, with precise jump-to-source for both legs. Branch pushed (origin/raw-search/foundation). New workstream — the missing **raw chapter-text** layer beneath glossary/knowledge/wiki (all lossy derivatives); serves authoring + extraction/trích-lục. Spec [`2026-06-07-raw-search.md`](../specs/2026-06-07-raw-search.md) (PART I design + PART II ATAM-lite eval; 7/7 confirm-at-BUILD resolved). Plan [`2026-06-07-raw-search.md`](../plans/2026-06-07-raw-search.md) (3 phases; ADJ-1..4 PO-acked).

--- a/docs/specs/2026-06-08-wiki-llm-building-mockup.html
+++ b/docs/specs/2026-06-08-wiki-llm-building-mockup.html
@@ -1,0 +1,666 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Wiki LLM-Building — Draft Mockup · LoreWeave</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&family=Noto+Serif+TC:wght@400;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ── LoreWeave dark amber theme tokens (mirrored from frontend/src/index.css) ── */
+  :root{
+    --background:#161311; --foreground:#F6F1E8;
+    --card:#1E1A17; --card-hover:#241F1B; --popover:#1E1A17;
+    --primary:#F0A93A; --primary-foreground:#110F0D; --primary-muted:#3D2E12;
+    --secondary:#2A2622; --secondary-foreground:#E8E1D6;
+    --muted:#2A2724; --muted-foreground:#A69E94; --muted-fg:#9E9488;
+    --accent:#449E8E; --destructive:#E04343; --success:#2DCA7E; --warning:#F5A623; --info:#5496E8;
+    --border:#332D28; --border-hover:#4A423B; --input:#262220; --ring:#EC9F33;
+    --radius:.5rem;
+    --reader-width:680px;
+    --sans:"Inter",system-ui,sans-serif;
+    --serif:"Lora","Noto Serif TC","Songti TC",Georgia,serif;
+    --mono:"JetBrains Mono",monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--background);color:var(--foreground);font-family:var(--sans);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+  .serif{font-family:var(--serif)}
+  .mono{font-family:var(--mono)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+  a{color:inherit;text-decoration:none}
+  svg{display:block}
+  .muted{color:var(--muted-foreground)}
+  .micro{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted-foreground)}
+
+  /* ── buttons ── */
+  .btn{display:inline-flex;align-items:center;gap:6px;border-radius:6px;font-size:13px;transition:.12s;white-space:nowrap}
+  .btn-primary{background:var(--primary);color:var(--primary-foreground);padding:7px 12px;font-size:12px;font-weight:600}
+  .btn-primary:hover{filter:brightness(1.1)}
+  .btn-outline{border:1px solid var(--border);color:var(--muted-foreground);padding:7px 12px}
+  .btn-outline:hover{background:var(--secondary);color:var(--foreground);border-color:var(--border-hover)}
+  .btn-ghost{color:var(--muted-foreground);padding:5px 8px}
+  .btn-ghost:hover{background:var(--secondary);color:var(--foreground)}
+  .icon-btn{width:24px;height:24px;display:inline-flex;align-items:center;justify-content:center;border-radius:6px;color:var(--muted-foreground)}
+  .icon-btn:hover{background:var(--secondary);color:var(--foreground)}
+
+  /* ── pills / badges ── */
+  .pill{display:inline-flex;align-items:center;gap:5px;border-radius:999px;padding:2px 10px;font-size:11px;font-weight:500}
+  .badge-ai{background:rgba(240,169,58,.13);color:var(--primary);border:1px solid rgba(240,169,58,.25)}
+  .badge-draft{background:rgba(245,166,35,.12);color:var(--warning)}
+  .badge-warn{background:rgba(245,166,35,.12);color:var(--warning)}
+  .badge-ok{background:rgba(45,202,126,.1);color:var(--success)}
+  .badge-danger{background:rgba(224,67,67,.12);color:var(--destructive)}
+  .badge-muted{background:var(--secondary);color:var(--muted-foreground)}
+  .badge-info{background:rgba(84,150,232,.12);color:var(--info)}
+
+  /* ── app shell ── */
+  .app{display:flex;height:100vh;overflow:hidden}
+  .sidebar{width:240px;flex-shrink:0;border-right:1px solid var(--border);background:var(--background);display:flex;flex-direction:column;padding:14px 10px}
+  .logo{display:flex;align-items:center;gap:9px;padding:6px 8px 16px}
+  .logo .tile{width:32px;height:32px;border-radius:8px;background:var(--primary);color:var(--primary-foreground);display:flex;align-items:center;justify-content:center;font-family:var(--serif);font-weight:700;font-size:18px}
+  .nav-sec{margin-top:14px}
+  .nav-sec h4{padding:6px 8px}
+  .nav-item{display:flex;align-items:center;gap:10px;padding:7px 8px;border-radius:6px;font-size:13px;color:var(--muted-foreground)}
+  .nav-item:hover{background:var(--secondary);color:var(--foreground)}
+  .nav-item.active{background:rgba(240,169,58,.15);color:var(--primary);font-weight:500}
+  .sidebar-foot{margin-top:auto;display:flex;align-items:center;gap:10px;padding:10px 8px;border-top:1px solid var(--border)}
+  .avatar-sm{width:28px;height:28px;border-radius:999px;background:rgba(240,169,58,.2);color:var(--primary);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600}
+  .main{flex:1;overflow-y:auto}
+  .container{max-width:1152px;margin:0 auto;padding:22px 40px 60px}
+
+  /* breadcrumb + tabs */
+  .crumb{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--muted-foreground);margin-bottom:10px}
+  .page-title{font-family:var(--serif);font-size:22px;font-weight:600}
+  .tabstrip{display:flex;gap:2px;border-bottom:1px solid var(--border);margin:16px 0 0}
+  .tab{padding:9px 14px;font-size:13px;font-weight:500;color:var(--muted-foreground);border-bottom:2px solid transparent;transition:.12s}
+  .tab:hover{color:var(--foreground)}
+  .tab.active{color:var(--primary);border-bottom-color:var(--primary)}
+
+  /* draft banner + screen switcher */
+  .draft-banner{background:linear-gradient(90deg,rgba(240,169,58,.08),transparent);border:1px solid rgba(240,169,58,.2);border-radius:8px;padding:12px 16px;margin:18px 0;display:flex;gap:14px;align-items:flex-start}
+  .switcher{display:flex;flex-wrap:wrap;gap:8px;margin:16px 0 20px}
+  .switcher button{border:1px solid var(--border);background:var(--card);color:var(--muted-foreground);padding:8px 14px;border-radius:999px;font-size:12.5px;font-weight:500}
+  .switcher button:hover{border-color:var(--border-hover);color:var(--foreground)}
+  .switcher button.active{background:var(--primary);color:var(--primary-foreground);border-color:var(--primary)}
+
+  .screen{display:none}
+  .screen.active{display:block}
+  .screen-label{font-size:12px;color:var(--muted-foreground);margin-bottom:10px}
+  .screen-label b{color:var(--primary)}
+
+  /* ── wiki two-pane ── */
+  .wiki-shell{display:flex;border:1px solid var(--border);border-radius:8px;overflow:hidden;min-height:560px;background:var(--background)}
+  .wiki-side{width:230px;flex-shrink:0;background:var(--card);border-right:1px solid var(--border);padding:12px 10px;display:flex;flex-direction:column;gap:10px}
+  .wiki-side-head{display:flex;align-items:center;gap:7px}
+  .wiki-side-head .ttl{font-family:var(--serif);font-size:15px;font-weight:600;flex:1}
+  .search{position:relative}
+  .search input{width:100%;height:30px;background:var(--input);border:1px solid var(--border);border-radius:6px;padding:0 8px 0 28px;color:var(--foreground);font-size:12.5px}
+  .search input::placeholder{color:var(--muted-foreground)}
+  .search svg{position:absolute;left:8px;top:8px}
+  .chips{display:flex;flex-wrap:wrap;gap:5px}
+  .chip{border-radius:999px;padding:3px 9px;font-size:11px;background:var(--secondary);color:var(--muted-foreground)}
+  .chip.active{font-weight:600}
+  .artlist{display:flex;flex-direction:column;gap:3px;overflow-y:auto}
+  .grp-h{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--muted-foreground);padding:9px 6px 3px}
+  .art{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:6px;font-size:13px;border-left:2px solid transparent;cursor:pointer}
+  .art:hover{background:var(--secondary)}
+  .art.sel{border-left-color:var(--primary);background:rgba(240,169,58,.08);font-weight:600}
+  .dot{width:6px;height:6px;border-radius:2px;flex-shrink:0}
+  .art .nm{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+  /* reader pane */
+  .wiki-read{flex:1;padding:22px 26px;overflow-y:auto;position:relative}
+  .read-head{display:flex;align-items:flex-start;gap:10px;flex-wrap:wrap}
+  .read-title{font-family:var(--serif);font-size:26px;font-weight:600;line-height:1.2}
+  .read-actions{margin-left:auto;display:flex;gap:7px}
+  .read-sub{font-size:11.5px;color:var(--muted-foreground);margin-top:6px}
+  .flagcard{margin:14px 0;border:1px solid rgba(245,166,35,.3);background:rgba(245,166,35,.06);border-radius:8px;padding:10px 12px;font-size:12.5px;display:flex;gap:9px}
+  .infobox{float:right;width:262px;margin:6px 0 14px 18px;border:1px solid var(--border);border-radius:8px;background:var(--card);overflow:hidden}
+  .infobox .ava{height:104px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#F0A93A,#9c6516)}
+  .infobox .ava span{font-family:var(--serif);font-size:46px;color:#1a1410;font-weight:600}
+  .infobox .ib-name{font-family:var(--serif);font-size:17px;font-weight:600;padding:10px 12px 2px}
+  .infobox .ib-kind{padding:0 12px 8px}
+  .ib-row{display:flex;font-size:12px;border-top:1px solid var(--border);padding:6px 12px}
+  .ib-row .k{width:74px;color:var(--muted-foreground);flex-shrink:0}
+  .ib-row .v{font-weight:500}
+  .body{font-family:var(--serif);font-size:16px;line-height:1.85;color:#ECE6DB}
+  .body h2{font-family:var(--serif);font-size:19px;font-weight:600;margin:20px 0 8px;color:#F6F1E8}
+  .body p{margin:10px 0}
+  sup.cite{color:var(--primary);font-size:11px;font-weight:600;cursor:pointer;padding:0 1px}
+  sup.cite:hover{text-decoration:underline}
+  .refs{clear:both;margin-top:24px;border-top:1px solid var(--border);padding-top:14px}
+  .refs h3{font-size:13px;font-weight:600;margin-bottom:10px;display:flex;align-items:center;gap:7px}
+  .ref{display:flex;align-items:center;gap:10px;padding:7px 0;font-size:12.5px;border-bottom:1px solid var(--border)}
+  .ref .n{color:var(--primary);font-weight:600;font-family:var(--mono);font-size:12px}
+  .ref .loc{color:var(--muted-foreground)}
+  .ref .relbar{width:54px;height:4px;border-radius:2px;background:var(--secondary);overflow:hidden;margin-left:auto}
+  .ref .relbar i{display:block;height:100%;background:var(--accent)}
+  .ref .jump{color:var(--accent);display:inline-flex;align-items:center;gap:4px;font-size:11.5px}
+  .ref .jump:hover{text-decoration:underline}
+
+  /* ── generic card ── */
+  .card{border:1px solid var(--border);border-radius:8px;background:var(--card)}
+  .card-p{padding:16px}
+
+  /* ── modal ── */
+  .modal-wrap{position:relative;border:1px solid var(--border);border-radius:10px;overflow:hidden;background:#100d0b}
+  .modal-dim{padding:36px;background:repeating-linear-gradient(45deg,#1212100a,#1212100a 12px,#00000010 12px,#00000010 24px)}
+  .modal{max-width:560px;margin:0 auto;background:var(--card);border:1px solid var(--border);border-radius:12px;box-shadow:0 24px 60px #000a}
+  .modal-h{padding:16px 18px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:9px}
+  .modal-h .t{font-family:var(--serif);font-size:17px;font-weight:600}
+  .modal-b{padding:18px;display:flex;flex-direction:column;gap:16px}
+  .modal-f{padding:14px 18px;border-top:1px solid var(--border);display:flex;justify-content:flex-end;gap:9px}
+  .fld{display:flex;flex-direction:column;gap:7px}
+  .fld>label{font-size:12px;font-weight:600;color:var(--secondary-foreground)}
+  .fld .hint{font-size:11px;color:var(--muted-foreground)}
+  .seg{display:flex;border:1px solid var(--border);border-radius:8px;overflow:hidden}
+  .seg button{flex:1;padding:9px;font-size:12.5px;color:var(--muted-foreground);text-align:center;border-right:1px solid var(--border)}
+  .seg button:last-child{border-right:none}
+  .seg button.on{background:rgba(240,169,58,.13);color:var(--primary);font-weight:600}
+  .seg button .s{display:block;font-size:10px;font-weight:400;color:var(--muted-foreground);margin-top:2px}
+  .select{display:flex;align-items:center;gap:8px;background:var(--input);border:1px solid var(--border);border-radius:6px;padding:8px 10px;font-size:13px}
+  .select .tag{margin-left:auto;font-size:10px}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .ground-ok{display:flex;gap:9px;align-items:flex-start;background:rgba(45,202,126,.07);border:1px solid rgba(45,202,126,.25);border-radius:8px;padding:10px 12px;font-size:12px}
+  .cost{display:flex;align-items:center;gap:10px;background:var(--secondary);border-radius:8px;padding:10px 12px;font-size:12.5px}
+  .cost .est{font-family:var(--mono);font-weight:600;color:var(--foreground)}
+
+  /* ── job progress ── */
+  .job-h{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:14px}
+  .progress{height:8px;border-radius:999px;background:var(--secondary);overflow:hidden;margin:6px 0 4px}
+  .progress i{display:block;height:100%;background:var(--primary)}
+  .steps{display:flex;gap:8px;flex-wrap:wrap;margin:12px 0}
+  .step{display:flex;align-items:center;gap:7px;border:1px solid var(--border);border-radius:999px;padding:6px 12px;font-size:12px;color:var(--muted-foreground)}
+  .step.done{border-color:rgba(45,202,126,.3);color:var(--success)}
+  .step.run{border-color:rgba(240,169,58,.4);color:var(--primary)}
+  .step .nb{font-family:var(--mono);font-size:11px;opacity:.7}
+  .entrow{display:flex;align-items:center;gap:10px;padding:9px 12px;border-bottom:1px solid var(--border);font-size:13px}
+  .entrow .en{flex:1}
+  .entrow .meta{font-size:11px;color:var(--muted-foreground)}
+  .spin{animation:spin 1s linear infinite}
+  @keyframes spin{to{transform:rotate(360deg)}}
+  .pausecard{border:1px solid rgba(245,166,35,.35);background:rgba(245,166,35,.07);border-radius:8px;padding:13px 15px;display:flex;align-items:center;gap:12px;margin-top:14px}
+
+  /* ── suggestions / diff ── */
+  .sug{border:1px solid var(--border);border-radius:8px;background:var(--card);margin-bottom:14px;overflow:hidden}
+  .sug-h{padding:12px 14px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;border-bottom:1px solid var(--border)}
+  .sug-b{padding:12px 14px}
+  .sug-reason{font-size:12.5px;color:var(--muted-foreground);margin-bottom:10px}
+  .diff{font-family:var(--mono);font-size:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden}
+  .diff div{padding:4px 10px;white-space:pre-wrap}
+  .diff .del{background:rgba(224,67,67,.08);color:#e88}
+  .diff .add{background:rgba(45,202,126,.08);color:#8d9}
+  .diff .ctx{color:var(--muted-foreground)}
+  .sug-f{padding:11px 14px;border-top:1px solid var(--border);display:flex;gap:8px;justify-content:flex-end}
+  .btn-accept{background:rgba(45,202,126,.14);color:var(--success);padding:7px 14px;border-radius:6px;font-size:12.5px;font-weight:600}
+  .btn-accept:hover{background:rgba(45,202,126,.22)}
+  .btn-reject{background:rgba(224,67,67,.12);color:var(--destructive);padding:7px 14px;border-radius:6px;font-size:12.5px;font-weight:600}
+  .btn-reject:hover{background:rgba(224,67,67,.2)}
+
+  .note{font-size:11.5px;color:var(--muted-foreground);margin-top:12px;font-style:italic}
+
+  /* ── change-feed (Knowledge updates / coi thay đổi) ── */
+  .info-banner{background:rgba(84,150,232,.07);border:1px solid rgba(84,150,232,.22);border-radius:8px;padding:11px 14px;font-size:12.5px;display:flex;gap:10px;align-items:flex-start;margin-bottom:14px}
+  .batchbar{position:sticky;top:0;z-index:5;display:flex;align-items:center;gap:12px;background:var(--card);border:1px solid var(--border-hover);border-radius:8px;padding:11px 14px;margin-bottom:14px;flex-wrap:wrap}
+  .sev{display:flex;gap:13px;font-size:11.5px}
+  .cbx{width:16px;height:16px;border:1.5px solid var(--border-hover);border-radius:4px;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;color:transparent}
+  .cbx.on{background:var(--primary);border-color:var(--primary);color:var(--primary-foreground)}
+  .chg{border:1px solid var(--border);border-left-width:3px;border-radius:8px;background:var(--card);margin-bottom:12px;overflow:hidden}
+  .chg-h{padding:11px 14px;display:flex;align-items:center;gap:11px;flex-wrap:wrap;border-bottom:1px solid var(--border)}
+  .chg-h .ic{width:30px;height:30px;border-radius:7px;display:flex;align-items:center;justify-content:center;flex-shrink:0}
+  .affrow{display:flex;align-items:center;gap:10px;padding:8px 14px;font-size:13px;border-top:1px solid var(--border)}
+  .affrow .part{font-size:11.5px;color:var(--muted-foreground)}
+  .chg-f{padding:8px 14px;border-top:1px solid var(--border);display:flex;gap:8px;justify-content:flex-end;align-items:center}
+  .chg-f a.diff-link{color:var(--accent);font-size:12px;margin-right:auto}
+  .mini-btn{padding:5px 11px;border-radius:6px;font-size:12px;font-weight:600}
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- ── left app sidebar ── -->
+  <aside class="sidebar">
+    <div class="logo"><div class="tile">L</div><span class="serif" style="font-size:17px;font-weight:600">LoreWeave</span></div>
+    <div class="nav-sec">
+      <h4 class="micro">Chính</h4>
+      <a class="nav-item active">📚 &nbsp;Sách</a>
+      <a class="nav-item">💬 &nbsp;Chat</a>
+      <a class="nav-item">🧠 &nbsp;Tri thức</a>
+      <a class="nav-item">🔎 &nbsp;Duyệt</a>
+    </div>
+    <div class="nav-sec">
+      <h4 class="micro">Quản lý</h4>
+      <a class="nav-item">🗑 &nbsp;Thùng rác</a>
+      <a class="nav-item">📊 &nbsp;Sử dụng</a>
+      <a class="nav-item">⚙️ &nbsp;Cài đặt</a>
+    </div>
+    <div class="sidebar-foot">
+      <div class="avatar-sm">C</div>
+      <div style="font-size:12px"><div style="font-weight:500">Claude Test</div><div class="muted" style="font-size:10px">claude-test@…</div></div>
+    </div>
+  </aside>
+
+  <!-- ── main ── -->
+  <main class="main">
+    <div class="container">
+      <!-- book chrome -->
+      <div class="crumb"><span>Sách</span><span>›</span><span class="serif" style="color:var(--foreground)">封神演义</span></div>
+      <div style="display:flex;align-items:center;gap:12px">
+        <div class="page-title">封神演义</div>
+        <span class="pill badge-muted">Bản dịch · 100 chương</span>
+      </div>
+      <div class="tabstrip">
+        <a class="tab">Chương</a><a class="tab">Dịch</a><a class="tab">Glossary</a>
+        <a class="tab">Bồi đắp</a><a class="tab active">Wiki</a><a class="tab">Chia sẻ</a><a class="tab">Cài đặt</a>
+      </div>
+
+      <!-- draft banner -->
+      <div class="draft-banner">
+        <div style="font-size:20px">✨</div>
+        <div style="font-size:12.5px;line-height:1.6">
+          <b style="color:var(--primary)">Draft mockup — Wiki LLM-Building (v2)</b>. Đây là bản phác thảo HTML phi chức năng để duyệt UX, không phải code thật.
+          Dữ liệu mẫu: 封神演义. Dùng nút bên dưới để chuyển giữa các màn. Theme/khung bám đúng app (dark amber · Lora · 2-pane).
+          <span class="muted">Map nguồn: <code class="mono">frontend/src/pages/book-tabs/WikiTab.tsx</code> · spec <code class="mono">docs/specs/2026-06-08-wiki-llm-building.md</code></span>
+        </div>
+      </div>
+
+      <!-- screen switcher -->
+      <div class="switcher">
+        <button class="active" data-s="reader">① Reader · bài AI (citations + badge + flags)</button>
+        <button data-s="generate">② Hộp thoại "Tạo bằng AI"</button>
+        <button data-s="job">③ Tiến trình multi-pass + cost cap</button>
+        <button data-s="suggest">④ Clobber-guard → Đề xuất</button>
+        <button data-s="changes">⑤ Cập nhật tri thức · coi thay đổi</button>
+      </div>
+
+      <!-- ════════ SCREEN 1 — READER (AI article) ════════ -->
+      <section class="screen active" id="reader">
+        <div class="screen-label">Màn <b>Reader</b> — bài wiki do AI sinh: badge "AI tạo · chưa kiểm chứng", banner cảnh báo verify-flag, văn xuôi có trích dẫn <code class="mono">[n]</code>, mục "Nguồn trích dẫn" với nút nhảy-tới-nguồn, nút <b>Tạo lại</b>.</div>
+        <div class="wiki-shell">
+          <!-- left -->
+          <div class="wiki-side">
+            <div class="wiki-side-head">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--primary)" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              <span class="ttl">Wiki</span>
+              <button class="icon-btn" title="Tạo bằng AI" style="color:var(--primary)">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg>
+              </button>
+              <button class="icon-btn" title="Tạo bài">＋</button>
+            </div>
+            <div class="muted" style="font-size:10px;padding:0 2px">18 bài · 11 do AI sinh</div>
+            <div class="search">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--muted-foreground)" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+              <input placeholder="Tìm trong wiki…" />
+            </div>
+            <div class="chips">
+              <span class="chip active" style="background:rgba(240,169,58,.14);color:var(--primary)">Tất cả</span>
+              <span class="chip">人物</span><span class="chip">势力</span><span class="chip">法宝</span><span class="chip">地点</span>
+            </div>
+            <div class="artlist">
+              <div class="grp-h">人物</div>
+              <div class="art sel"><span class="dot" style="background:#e0884a"></span><span class="nm">姜子牙</span><svg width="11" height="11" viewBox="0 0 24 24" fill="var(--primary)"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg></div>
+              <div class="art"><span class="dot" style="background:#e0884a"></span><span class="nm">哪吒</span></div>
+              <div class="art"><span class="dot" style="background:#e0884a"></span><span class="nm">妲己</span><span class="pill badge-draft" style="padding:0 7px;font-size:9px">Nháp</span></div>
+              <div class="art"><span class="dot" style="background:#e0884a"></span><span class="nm">杨戬</span></div>
+              <div class="art"><span class="dot" style="background:#e0884a"></span><span class="nm">黄飞虎</span></div>
+              <div class="grp-h">势力</div>
+              <div class="art"><span class="dot" style="background:#5496E8"></span><span class="nm">阐教</span></div>
+              <div class="art"><span class="dot" style="background:#5496E8"></span><span class="nm">截教</span></div>
+              <div class="art"><span class="dot" style="background:#5496E8"></span><span class="nm">西周</span></div>
+              <div class="grp-h">法宝</div>
+              <div class="art"><span class="dot" style="background:#449E8E"></span><span class="nm">打神鞭</span></div>
+              <div class="art"><span class="dot" style="background:#449E8E"></span><span class="nm">杏黄旗</span></div>
+            </div>
+          </div>
+
+          <!-- reader -->
+          <div class="wiki-read">
+            <div class="read-head">
+              <div>
+                <div class="read-title">姜子牙</div>
+                <div class="read-sub">Sửa lần cuối 2026-06-08 · 3 phiên bản · <span style="color:var(--primary)">由 AI 生成</span> · grounded trên 3 đoạn gốc</div>
+              </div>
+              <div class="read-actions">
+                <span class="pill" style="background:#e0884a18;color:#e0884a">人物</span>
+                <span class="pill badge-ai">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg>
+                  AI tạo · chưa kiểm chứng
+                </span>
+              </div>
+            </div>
+
+            <div style="display:flex;gap:7px;margin-top:12px">
+              <button class="btn btn-primary"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Sửa</button>
+              <button class="btn btn-outline"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>Lịch sử</button>
+              <button class="btn btn-outline" style="color:var(--primary);border-color:rgba(240,169,58,.35)"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.7 9.7 0 0 0-6.7 2.8L3 8"/><path d="M3 3v5h5"/></svg>Tạo lại</button>
+            </div>
+
+            <!-- verify-flag banner -->
+            <div class="flagcard">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2" style="flex-shrink:0;margin-top:1px"><path d="m21.7 18-9-15.5a2 2 0 0 0-3.4 0L0 18a2 2 0 0 0 1.7 3h18.6a2 2 0 0 0 1.7-3z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
+              <div>
+                <b>1 điểm cần kiểm chứng</b> — đoạn "封神" nhắc tới <i>佛法</i>; <code class="mono">CanonVerifier</code> gắn cờ <b>xung đột thời đại</b> (商周 vs 佛教) · mức <b>thấp</b>.
+                <a style="color:var(--accent);margin-left:6px">Xem tất cả cờ →</a>
+                <div class="muted" style="margin-top:3px;font-size:11px">Bài vẫn ở trạng thái <b>Nháp</b>; chưa bị chặn xuất bản (<code class="mono">publish_blocked=false</code>). Chủ sách duyệt rồi mới publish.</div>
+              </div>
+            </div>
+
+            <!-- infobox -->
+            <div class="infobox">
+              <div class="ava"><span>姜</span></div>
+              <div class="ib-name">姜子牙</div>
+              <div class="ib-kind"><span class="pill" style="background:#e0884a18;color:#e0884a">人物</span></div>
+              <div class="ib-row"><span class="k">姓名</span><span class="v">姜尚</span></div>
+              <div class="ib-row"><span class="k">字</span><span class="v">子牙</span></div>
+              <div class="ib-row"><span class="k">道号</span><span class="v">飞熊</span></div>
+              <div class="ib-row"><span class="k">师承</span><span class="v">元始天尊（玉虚宫）</span></div>
+              <div class="ib-row"><span class="k">阵营</span><span class="v">西周 · 阐教</span></div>
+              <div class="ib-row"><span class="k">出场</span><span class="v">第十五回</span></div>
+            </div>
+
+            <!-- body with citations -->
+            <div class="body">
+              <p>姜子牙，姓姜名尚，字子牙，道号飞熊，是阐教掌教元始天尊门下弟子，于昆仑山玉虚宫修行四十载<sup class="cite">[1]</sup>。因仙道难成、命中无份成仙，奉师命下山辅佐周室，执掌封神大业，是全书贯穿始终的核心人物<sup class="cite">[1]</sup>。</p>
+              <h2>生平</h2>
+              <p>姜子牙下山后际遇坎坷，曾于朝歌以卖面、编笊篱等营生糊口，半生潦倒，年逾七旬方遇明主<sup class="cite">[2]</sup>。后于渭水之畔以无饵之钩垂钓，借此静待时机，终得周文王访贤，拜为丞相，世称"姜太公"<sup class="cite">[2]</sup>。</p>
+              <h2>封神</h2>
+              <p>武王伐纣功成之后，姜子牙奉元始天尊符敕，登台敕封阵亡群雄之魂魄，依其生前功过分定神位，是为"封神"<sup class="cite">[3]</sup>。他手持打神鞭、肩担封神榜，号令三界神祇，奠定了新的天庭秩序<sup class="cite">[3]</sup>。</p>
+            </div>
+
+            <!-- references -->
+            <div class="refs">
+              <h3><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--primary)" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Nguồn trích dẫn <span class="muted" style="font-weight:400;font-size:11px">· hybrid retrieval · rerank ✓</span></h3>
+              <div class="ref"><span class="n">[1]</span><span>第十五回 · 昆仑山元始天尊命姜尚下山</span><span class="loc mono" style="font-size:11px">block 34</span><span class="relbar"><i style="width:94%"></i></span><a class="jump">Nhảy tới nguồn<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg></a></div>
+              <div class="ref"><span class="n">[2]</span><span>第二十三回 · 渭水文王访太公</span><span class="loc mono" style="font-size:11px">block 12</span><span class="relbar"><i style="width:88%"></i></span><a class="jump">Nhảy tới nguồn<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg></a></div>
+              <div class="ref"><span class="n">[3]</span><span>第九十九回 · 姜子牙归国封神</span><span class="loc mono" style="font-size:11px">block 8</span><span class="relbar"><i style="width:91%"></i></span><a class="jump">Nhảy tới nguồn<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg></a></div>
+              <div class="note">Mỗi <code class="mono">[n]</code> neo vào <code class="mono">block_index</code> của chương → tái dùng precise-scroll <code class="mono">?block=N</code> của raw-search. Mọi câu khẳng định đều phải có cite (structural cite-enforcement); câu không grounded bị bỏ lúc parse.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════ SCREEN 2 — GENERATE DIALOG ════════ -->
+      <section class="screen" id="generate">
+        <div class="screen-label">Màn <b>Tạo bằng AI</b> — thay nút "1-bấm-chạy-luôn" hiện tại bằng hộp thoại: toggle Mẫu/AI, chọn model (per-step prose vs verify), phạm vi, trạng thái grounding, và <b>ước tính chi phí</b>.</div>
+        <div class="modal-wrap"><div class="modal-dim">
+          <div class="modal">
+            <div class="modal-h">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="var(--primary)"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg>
+              <span class="t">Tạo Wiki bằng AI</span>
+            </div>
+            <div class="modal-b">
+              <div class="fld">
+                <label>Chế độ</label>
+                <div class="seg">
+                  <button>Mẫu cố định<span class="s">tất định · miễn phí · như cũ</span></button>
+                  <button class="on">AI tạo sinh<span class="s">grounded · có trích dẫn · multi-pass</span></button>
+                </div>
+              </div>
+              <div class="grid2">
+                <div class="fld">
+                  <label>Mô hình văn phong <span class="muted" style="font-weight:400">(prose)</span></label>
+                  <div class="select">🪶 Claude Opus 4.8 <span class="pill badge-info tag">BYOK</span></div>
+                  <span class="hint">Bước viết — model mạnh.</span>
+                </div>
+                <div class="fld">
+                  <label>Mô hình kiểm chứng <span class="muted" style="font-weight:400">(verify)</span></label>
+                  <div class="select">⚡ Qwen3-7B · 本地 <span class="pill badge-muted tag">rẻ</span></div>
+                  <span class="hint">Để trống → dùng model văn phong.</span>
+                </div>
+              </div>
+              <div class="fld">
+                <label>Phạm vi</label>
+                <div class="chips" style="gap:6px">
+                  <span class="chip" style="background:rgba(240,169,58,.14);color:var(--primary)">人物 ✓</span>
+                  <span class="chip" style="background:rgba(240,169,58,.14);color:var(--primary)">势力 ✓</span>
+                  <span class="chip" style="background:rgba(240,169,58,.14);color:var(--primary)">法宝 ✓</span>
+                  <span class="chip">地点</span>
+                  <span class="muted" style="font-size:11px;align-self:center">· chỉ entity chưa có bài</span>
+                </div>
+              </div>
+              <div class="grid2">
+                <div class="fld">
+                  <label>Giới hạn số bài / lần</label>
+                  <div class="select"><input value="20" style="background:none;border:none;color:inherit;width:100%;font-size:13px" /></div>
+                </div>
+                <div class="fld">
+                  <label>Ngôn ngữ sinh</label>
+                  <div class="select">自动 · theo BookProfile <span class="pill badge-muted tag">中文</span></div>
+                </div>
+              </div>
+              <div class="ground-ok">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2" style="flex-shrink:0;margin-top:1px"><path d="M20 6 9 17l-5-5"/></svg>
+                <div><b>Sách đã lập chỉ mục</b> · grounding = hybrid (lexical + semantic) + rerank bật. Nếu chưa index → tự degrade về lexical + KG + attrs, kèm gợi ý "index để chất lượng tốt hơn".</div>
+              </div>
+              <div class="cost">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--muted-foreground)" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5"/><path d="M12 16h.01"/></svg>
+                <div>Ước tính <span class="est">~20 bài × ~1.2k tok ≈ $0.18</span></div>
+                <div class="muted" style="margin-left:auto">Ngân sách $5.00 · tháng này đã dùng $0.32</div>
+              </div>
+            </div>
+            <div class="modal-f">
+              <button class="btn btn-outline">Hủy</button>
+              <button class="btn btn-primary"><svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg>Tạo sinh</button>
+            </div>
+          </div>
+        </div></div>
+      </section>
+
+      <!-- ════════ SCREEN 3 — JOB PROGRESS ════════ -->
+      <section class="screen" id="job">
+        <div class="screen-label">Màn <b>Tiến trình</b> — poll job-row (SSOT): thanh tiến trình, <b>4 pass</b> của entity đang xử lý, kết quả từng entity (đã tạo / bỏ qua vì thiếu grounding / có cảnh báo), và ví dụ trạng thái <b>tạm dừng do chạm trần chi phí</b> (resumable).</div>
+        <div class="card card-p">
+          <div class="job-h">
+            <span class="pill badge-ai"><span class="spin" style="display:inline-block">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.2-8.5"/></svg></span> Đang chạy</span>
+            <span class="mono muted" style="font-size:11px">job_id 7f3a…c21</span>
+            <span class="muted" style="margin-left:auto;font-size:12.5px">Chi phí <span class="mono" style="color:var(--foreground)">$0.11</span> / $5.00</span>
+          </div>
+          <div style="font-size:12.5px;margin-bottom:2px">12 / 20 entity</div>
+          <div class="progress"><i style="width:60%"></i></div>
+
+          <div style="margin-top:16px;font-size:13px">Đang xử lý: <b>妲己</b> <span class="muted">(人物)</span></div>
+          <div class="steps">
+            <span class="step done"><span class="nb">①</span> Viết <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6 9 17l-5-5"/></svg></span>
+            <span class="step done"><span class="nb">②</span> Kiểm tra quy tắc (cite) <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6 9 17l-5-5"/></svg></span>
+            <span class="step run"><span class="nb">③</span> Kiểm chứng (CanonVerifier) <span class="spin" style="display:inline-block"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.2-8.5"/></svg></span></span>
+            <span class="step"><span class="nb">④</span> Sửa (chỉ nếu HIGH · tối đa 1 vòng)</span>
+          </div>
+          <div class="note" style="margin-top:4px">Vòng sửa chỉ kích hoạt khi có cờ HIGH; <code class="mono">keep-if-improved</code> tất định — chỉ nhận bản sửa nếu rule-count giảm (LLM không lái quyết định).</div>
+
+          <div style="margin-top:18px;border:1px solid var(--border);border-radius:8px;overflow:hidden">
+            <div class="entrow"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg><span class="en">姜子牙</span><span class="meta">3 trích dẫn</span><span class="pill badge-ok" style="font-size:10px">Đã tạo</span></div>
+            <div class="entrow"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg><span class="en">哪吒</span><span class="meta">5 trích dẫn</span><span class="pill badge-ok" style="font-size:10px">Đã tạo</span></div>
+            <div class="entrow"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2"><path d="m21.7 18-9-15.5a2 2 0 0 0-3.4 0L0 18a2 2 0 0 0 1.7 3h18.6a2 2 0 0 0 1.7-3z"/></svg><span class="en">杨戬</span><span class="meta">4 trích dẫn · 1 cờ thời đại</span><span class="pill badge-warn" style="font-size:10px">Đã tạo · cảnh báo</span></div>
+            <div class="entrow"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--muted-foreground)" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg><span class="en">申公豹</span><span class="meta">grounding không đủ — không bịa</span><span class="pill badge-muted" style="font-size:10px">Bỏ qua</span></div>
+            <div class="entrow"><span class="spin"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--primary)" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.2-8.5"/></svg></span><span class="en">妲己</span><span class="meta">pass ③/④…</span><span class="pill badge-ai" style="font-size:10px">Đang xử lý</span></div>
+            <div class="entrow" style="border-bottom:none;color:var(--muted-foreground)"><span style="width:14px;text-align:center">·</span><span class="en">+ 8 entity trong hàng đợi</span></div>
+          </div>
+
+          <!-- paused example -->
+          <div class="pausecard">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2" style="flex-shrink:0"><rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/></svg>
+            <div style="flex:1;font-size:12.5px">
+              <b>Ví dụ trạng thái: Tạm dừng do chạm trần chi phí.</b> Job chuyển <code class="mono">status='paused'</code> — <b>việc đã xong không mất</b>; khi tiếp tục, resume <i>bỏ qua entity đã sinh</i> trước khi tốn token (skip-done-before-spend → hội tụ).
+            </div>
+            <button class="btn btn-primary">Tiếp tục</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════ SCREEN 4 — SUGGESTIONS (clobber guard) ════════ -->
+      <section class="screen" id="suggest">
+        <div class="screen-label">Màn <b>Đề xuất</b> — khi "Tạo lại" một bài <b>đã có chỉnh sửa của người</b>, clobber-guard <i>không ghi đè</i> mà đẩy bản AI thành <b>đề xuất kèm diff</b> để chủ sách duyệt (tái dùng đúng bảng <code class="mono">wiki_suggestions</code> sẵn có).</div>
+        <div class="card card-p">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
+            <div class="serif" style="font-size:17px;font-weight:600">Đề xuất & AI tái tạo</div>
+            <span class="pill badge-muted">2 chờ duyệt</span>
+          </div>
+
+          <!-- AI-regen-as-suggestion (the clobber guard) -->
+          <div class="sug">
+            <div class="sug-h">
+              <span class="pill badge-ai"><svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg>AI tái tạo (grounded)</span>
+              <span style="font-weight:600">哪吒</span>
+              <span class="muted" style="font-size:12px">→ chủ sách · vừa xong</span>
+            </div>
+            <div class="sug-b">
+              <div class="sug-reason">⚠ Bài này <b>đã có chỉnh sửa thủ công</b> (đã publish, có revision của owner) → bản AI <b>không ghi đè</b> mà chuyển thành đề xuất chờ duyệt. <span class="muted">(<code class="mono">author_type='ai'</code> chỉ được refresh draft chưa ai chạm.)</span></div>
+              <div class="diff">
+                <div class="ctx">  哪吒，乾元山金光洞太乙真人之徒，灵珠子转世<sup style="color:var(--primary)">[1]</sup>。</div>
+                <div class="del">- 七岁时大闹东海，抽龙筋、打死巡海夜叉。</div>
+                <div class="add">+ 七岁时于九湾河戏水，以混天绫搅动龙宫，先后击杀巡海夜叉李艮与龙王三太子敖丙<sup style="color:var(--primary)">[2]</sup>。</div>
+                <div class="add">+ 后剔骨还父、削肉还母，由太乙真人以莲花莲藕重塑其身<sup style="color:var(--primary)">[3]</sup>。</div>
+              </div>
+            </div>
+            <div class="sug-f">
+              <button class="btn-reject">Từ chối</button>
+              <button class="btn-accept">Chấp nhận → áp vào bài</button>
+            </div>
+          </div>
+
+          <!-- a regular community suggestion for contrast -->
+          <div class="sug">
+            <div class="sug-h">
+              <span class="pill badge-info">👥 Cộng đồng</span>
+              <span style="font-weight:600">姜子牙</span>
+              <span class="muted" style="font-size:12px">bởi reader_8821 · 2 giờ trước</span>
+            </div>
+            <div class="sug-b">
+              <div class="sug-reason">"道号应为'飞熊'而非'非熊'，见第二十三回。"</div>
+              <div class="diff">
+                <div class="del">- 道号非熊</div>
+                <div class="add">+ 道号飞熊</div>
+              </div>
+            </div>
+            <div class="sug-f">
+              <button class="btn-reject">Từ chối</button>
+              <button class="btn-accept">Chấp nhận</button>
+            </div>
+          </div>
+          <div class="note">Cả AI-tái-tạo lẫn đề xuất cộng đồng đi qua <b>cùng một hàng đợi duyệt</b> — giữ đúng tinh thần H0: AI luôn ở dạng chờ-người-duyệt, không tự ghi đè canon.</div>
+        </div>
+      </section>
+
+      <!-- ════════ SCREEN 5 — KNOWLEDGE UPDATES (coi thay đổi) ════════ -->
+      <section class="screen" id="changes">
+        <div class="screen-label">Màn <b>Cập nhật tri thức</b> (§5.3) — knowledge đổi → bài bị lật stale, <b>gom vào ledger</b> chờ duyệt. Coi <i>thay đổi gì</i> + <i>ảnh hưởng bài nào</i>, gom batch tạo lại có <b>ước tính chi phí</b>. Deferred + user-gated: <b>không gì tự regenerate</b>.</div>
+        <div class="card card-p">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
+            <div class="serif" style="font-size:17px;font-weight:600">Cập nhật tri thức</div>
+            <span class="pill badge-warn">5 bài outdated</span>
+            <button class="btn btn-ghost" style="margin-left:auto;font-size:12px"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.7 9.7 0 0 0-6.7 2.8L3 8"/><path d="M3 3v5h5"/></svg>Quét lại fingerprint</button>
+          </div>
+
+          <div class="info-banner">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--info)" stroke-width="2" style="flex-shrink:0;margin-top:1px"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+            <div>Thay đổi của knowledge được <b>ghi nhận tự động</b> và gom tại đây (deferred ledger — <b>không phải realtime CDC</b>). Cờ tự lật nhưng <b>không bài nào được tạo lại</b> cho tới khi bạn chọn — vì regenerate tốn token.</div>
+          </div>
+
+          <!-- batch action bar -->
+          <div class="batchbar">
+            <span class="cbx on"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span>
+            <span style="font-size:12.5px"><b>4</b> đã chọn</span>
+            <div class="sev" style="margin-left:6px">
+              <span style="color:var(--destructive)">● 1 citation gãy</span>
+              <span style="color:var(--warning)">● 2 cấu trúc</span>
+              <span style="color:var(--info)">● 2 nội dung</span>
+            </div>
+            <div style="margin-left:auto;display:flex;align-items:center;gap:10px">
+              <span class="muted" style="font-size:12px">Ước tính <span class="mono" style="color:var(--foreground)">~$0.14</span> · cost-cap $5.00</span>
+              <button class="btn btn-outline">Bỏ qua</button>
+              <button class="btn btn-primary"><svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg>Tạo lại đã chọn</button>
+            </div>
+          </div>
+
+          <!-- ① citation broken (hard) -->
+          <div class="chg" style="border-left-color:var(--destructive)">
+            <div class="chg-h">
+              <div class="ic" style="background:rgba(224,67,67,.12);color:var(--destructive)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></div>
+              <div style="flex:1">
+                <div style="font-weight:600">第十二回 đã bị xóa</div>
+                <div class="muted" style="font-size:11px"><code class="mono">chapter.deleted</code> · 5 phút trước · citation neo vào chương này giờ gãy</div>
+              </div>
+              <span class="pill badge-danger">Citation gãy</span>
+            </div>
+            <div class="affrow"><span class="cbx on"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span class="dot" style="background:#e0884a"></span><span style="font-weight:500">哪吒</span><span class="part">— [2] neo block 18 @ 第十二回 → không còn canon</span><span style="margin-left:auto" class="pill badge-danger" >Cứng</span></div>
+            <div class="chg-f"><a class="diff-link">Xem thay đổi</a><button class="btn-reject mini-btn">Bỏ qua</button><button class="btn-accept mini-btn">Tạo lại</button></div>
+          </div>
+
+          <!-- ② chapter republished (content) → cascade 2 articles -->
+          <div class="chg" style="border-left-color:var(--info)">
+            <div class="chg-h">
+              <div class="ic" style="background:rgba(84,150,232,.12);color:var(--info)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.7 9.7 0 0 0-6.7 2.8L3 8"/><path d="M3 3v5h5"/></svg></div>
+              <div style="flex:1">
+                <div style="font-weight:600">第二十三回《妲己进宫》 tái-publish <span class="muted" style="font-weight:400;font-size:11px">(revision mới)</span></div>
+                <div class="muted" style="font-size:11px"><code class="mono">chapter.published</code> · 1 giờ trước · đoạn gốc đổi → join 2 bài đang cite chương này</div>
+              </div>
+              <span class="pill badge-info">Chương tái-publish</span>
+            </div>
+            <div class="affrow"><span class="cbx on"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span class="dot" style="background:#e0884a"></span><span style="font-weight:500">妲己</span><span class="part">— [1][3] grounding drift</span><span style="margin-left:auto" class="pill badge-info">Nội dung</span></div>
+            <div class="affrow"><span class="cbx on"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span class="dot" style="background:#e0884a"></span><span style="font-weight:500">姜子牙</span><span class="part">— [2] neo block 12 @ 第二十三回</span><span style="margin-left:auto" class="pill badge-info">Nội dung</span></div>
+            <div class="chg-f"><a class="diff-link">Xem thay đổi</a><button class="btn-reject mini-btn">Bỏ qua</button><button class="btn-accept mini-btn">Tạo lại cả 2</button></div>
+          </div>
+
+          <!-- ③ entity merged (structural) -->
+          <div class="chg" style="border-left-color:var(--warning)">
+            <div class="chg-h">
+              <div class="ic" style="background:rgba(245,166,35,.12);color:var(--warning)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M7 4 3 8l4 4"/><path d="M3 8h13a4 4 0 0 1 4 4v8"/></svg></div>
+              <div style="flex:1">
+                <div style="font-weight:600">Gộp 姬昌 → 周文王</div>
+                <div class="muted" style="font-size:11px"><code class="mono">glossary.entity_merged</code> · 3 giờ trước · neighborhood + alias gộp · redirect 姬昌 đã tạo · revisions của 姬昌 đã giữ</div>
+              </div>
+              <span class="pill badge-warn">Đã gộp</span>
+            </div>
+            <div class="affrow"><span class="cbx on"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span class="dot" style="background:#e0884a"></span><span style="font-weight:500">周文王</span><span class="part">— context đã gộp → nên sinh lại từ ngữ cảnh hợp nhất</span><span style="margin-left:auto" class="pill badge-warn">Cấu trúc</span></div>
+            <div class="chg-f"><a class="diff-link">Xem thay đổi</a><button class="btn-reject mini-btn">Bỏ qua</button><button class="btn-accept mini-btn">Tạo lại</button></div>
+          </div>
+
+          <!-- ④ attr edited + human-edited article → routes to suggestion -->
+          <div class="chg" style="border-left-color:var(--warning)">
+            <div class="chg-h">
+              <div class="ic" style="background:rgba(245,166,35,.12);color:var(--warning)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg></div>
+              <div style="flex:1">
+                <div style="font-weight:600">Thêm attr 法宝: 哮天犬 <span class="muted" style="font-weight:400">(杨戬)</span></div>
+                <div class="muted" style="font-size:11px"><code class="mono">glossary.entity_updated</code> · hôm qua</div>
+              </div>
+              <span class="pill badge-muted">Sửa attr</span>
+            </div>
+            <div class="affrow"><span class="cbx"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span class="dot" style="background:#e0884a"></span><span style="font-weight:500">杨戬</span><span class="part">— ⚠ bài <b>đã có chỉnh sửa người</b> → tạo lại sẽ thành <b>đề xuất</b>, không ghi đè (clobber-guard)</span><span style="margin-left:auto" class="pill badge-ai">→ Đề xuất</span></div>
+            <div class="chg-f"><a class="diff-link">Xem thay đổi</a><button class="btn-reject mini-btn">Bỏ qua</button><button class="btn-accept mini-btn">Tạo đề xuất</button></div>
+          </div>
+
+          <!-- ⑤ recipe upgraded (global, advisory, unchecked) -->
+          <div class="chg" style="border-left-color:var(--accent)">
+            <div class="chg-h">
+              <div class="ic" style="background:rgba(68,158,142,.12);color:var(--accent)"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3z"/></svg></div>
+              <div style="flex:1">
+                <div style="font-weight:600">Prompt nâng v2 → v3 <span class="muted" style="font-weight:400;font-size:11px">(pipeline_version — same-input drift)</span></div>
+                <div class="muted" style="font-size:11px">phát hiện bởi <b>fingerprint sweep</b> · không phải event · không bắt buộc</div>
+              </div>
+              <span class="pill" style="background:rgba(68,158,142,.12);color:var(--accent)">Công thức mới</span>
+            </div>
+            <div class="affrow"><span class="cbx"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span class="muted" style="font-size:12.5px">11 bài AI có thể sinh lại tốt hơn với prompt v3 — chỉ làm nếu bạn muốn</span><a style="margin-left:auto;color:var(--accent);font-size:12px">Xem 11 bài →</a></div>
+          </div>
+
+          <div class="note">Mỗi dòng = join <code class="mono">wiki_article_source_usage</code> (capture lúc sinh) × event/sweep. Cờ <code class="mono">is_knowledge_stale</code> tự lật; <b>token chỉ tốn khi bạn bấm Tạo lại</b>. Severity: 🔴 citation gãy (cứng) · 🟡 cấu trúc (kind/merge) · 🔵 nội dung (attr/grounding). Bài người-đã-sửa luôn đi đường đề xuất.</div>
+        </div>
+      </section>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  const btns=document.querySelectorAll('.switcher button');
+  const screens=document.querySelectorAll('.screen');
+  btns.forEach(b=>b.addEventListener('click',()=>{
+    btns.forEach(x=>x.classList.remove('active'));
+    screens.forEach(s=>s.classList.remove('active'));
+    b.classList.add('active');
+    document.getElementById(b.dataset.s).classList.add('active');
+    document.querySelector('.main').scrollTo({top:0,behavior:'smooth'});
+  }));
+</script>
+</body>
+</html>

--- a/docs/specs/2026-06-08-wiki-llm-building.md
+++ b/docs/specs/2026-06-08-wiki-llm-building.md
@@ -1,0 +1,380 @@
+# Wiki LLM-Building Upgrade — Design Spec (v3, + change-control layer)
+
+- **Date:** 2026-06-08
+- **Branch:** `wiki/llm-building` (cut from `main` @ `09fca211`)
+- **Phase:** DESIGN v3 — v2 (4-pipeline sibling-review hardening) + a **Change-Control layer** from a
+  knowledge-change architecture evaluation (3-pipeline mining: event bus, staleness precedents, entity
+  lifecycle). Awaiting PO sign-off.
+- **Task size:** **XL** — services: knowledge, glossary, book, provider-registry, learning; schema; new
+  worker; new contracts; FE. `/loom` or `/amaw` BUILD recommended. Ships in **phases** (see §8).
+- **Status legend:** 🔒 LOCKED · 🟡 PROPOSED · ✅ RESOLVED-by-review · 🟥 P0 · 🟧 P1 · 🟩 P2 · 🟦 phase-2
+
+> **v1 → v2:** single-shot was under-designed. Sibling pipelines proved a grounded generator **cannot
+> police its own grounding** (translation-v3), raw novel text is the **highest-risk injection vector**
+> (lore-enrichment), and `wiki_articles.entity_id UNIQUE` makes naive writeback **clobber human edits**.
+> → bounded multi-pass + 2 P0 safety fixes + feedback/eval flywheel.
+>
+> **v2 → v3:** wiki is not N one-shot articles — it is a **materialized view over a versioned, multi-service
+> knowledge base that changes continuously** (chapters translated, attrs edited, entities merged, enrichments
+> promoted, KG edges added). The hard problem is **controlling that change**. PO policy locked: **(1) NOT
+> realtime CDC — capture change, defer the work in a DB ledger; (2) regeneration costs tokens → the user
+> decides what/when to regenerate.** v3 adds a Change-Control layer (§5) split into *capture* (cheap, auto,
+> **MVP**) vs *defer + decide* (**phase-2**, user-gated), plus entity-lifecycle propagation and 2 pre-existing
+> data-loss bug fixes.
+
+---
+
+## 1. Problem
+
+The wiki feature (in **glossary-service**, Go) is "mostly CRUD". Its generator —
+`POST /v1/glossary/books/{book_id}/wiki/generate` → `generateWikiStubs` → `renderWikiBody` — is a
+**deterministic Go template renderer with NO LLM**: it concatenates glossary attrs + 1-hop KG relations +
+promoted enrichments into fixed Chinese TipTap sections. Articles read as attribute dumps, not prose.
+
+Worse, even a great generator is not enough: a wiki is a **large, evolving derived corpus**. An article
+generated today is built from knowledge-state-at-T; as the book evolves to T+1 the article silently goes
+**stale**. The design must therefore treat the wiki as an **incrementally-(re)materialized view** whose change
+is *captured, deferred, and reconciled under user control* — not a batch of fire-and-forget generations.
+
+**Goals:** (a) grounded, cited, readable LLM articles from the source text; (b) **control knowledge change** —
+generate / resume / merge / **update** a huge corpus without losing human work or silently serving stale
+prose; keep the deterministic renderer as a degradation floor and glossary as the authored SSOT.
+
+### Non-goals
+- Not replacing wiki CRUD / revisions / suggestions (stays in glossary).
+- Not writing Neo4j canonical content (Q2 LOCKED — read-only KG).
+- Not auto-publishing AI output (lands `draft`, human promotes — H0 quarantine ethos).
+- **Not realtime regeneration.** Change is captured and deferred; regeneration is always user-initiated.
+
+---
+
+## 2. Architecture (🔒 LOCKED)
+
+The LLM wiki-generation flow lives in **knowledge-service** (Python) as a module + **durable-stream-driven
+worker** — NOT glossary (Go; LLM SDKs are Python-only; language rule + provider-gateway invariant). It owns
+the raw-search retriever (call **in-process**), the KG, and installs the grounding SDK. glossary stays the
+SSOT + front door. Code template = **lore-enrichment** `runner→generate→verify→writeback`.
+
+Two cooperating planes:
+- **Generation plane** (§3–4): produce one grounded article on demand.
+- **Change-control plane** (§5): track what each article was built from, *capture* knowledge change into a
+  *deferred ledger* (no work), and let the user *decide* what to regenerate (cost-gated).
+
+### 2.1 End-to-end flow (generation)
+
+```
+FE → api-gateway-bff
+  → glossary POST /v1/glossary/books/{book_id}/wiki/generate   (Go — auth, entity selection, SSOT front door)
+       body: { kind_codes?, limit?, model_ref?, model_source?, step_models?, force? }
+       ├─ model_ref ABSENT → deterministic renderWikiBody (synchronous, unchanged) ............. FALLBACK FLOOR
+       └─ model_ref PRESENT → POST knowledge /internal/knowledge/books/{id}/wiki/generate
+            knowledge: cost preflight (budget.can_start_job) → INSERT wiki_gen_jobs row
+                       → XADD loreweave:events:wiki-gen {job_id,user_id,book_id} → return 202 {job_id}
+  ── knowledge-service wiki-gen CONSUMER (flag-gated, clones resume_consumer.py) ──
+     for each entity (skip if already generated this job — skip-done-before-spend):
+       budget.charge_or_pause → on breach: job 'paused', stop (resumable)
+       0. CONTEXT  attrs + KG neighborhood + raw passages (in-process run_hybrid_search, rerank=true)
+       0b. SANITIZE every untrusted string BEFORE prompting (neutralize_injection)                🟥 P0
+       1. WRITE (prose model) → grounded TipTap body; claims tagged grounded + cite-id; BookProfile-shaped
+       2. RULE-GATE (free) → every [n] resolves to a passage? sections present? drop un-cited claims        🟧
+       3. VERIFY (verify model) → CanonVerifier + decide_auto_reject                                         🟧
+       4. REVISE (prose model) → only if HIGH flags, max 1 round; keep-if-improved deterministic
+       5. CITE compose_cites → weave [n];  capture build_inputs fingerprint + source usage (§5.1)            🟥
+       6. reconcile cost; advance_cursor
+       7. WRITEBACK POST glossary /internal/books/{id}/wiki/articles { body, provenance(+build_inputs),
+                    source_usage[], publish_blocked, verify_flags } (retried; idempotent; clobber-guarded)   🟥
+  ── glossary (Go) ──
+       upsert-by-entity (entity_id UNIQUE): AI overwrites ONLY untouched author_type='ai' draft;
+       else → wiki_suggestion; tx INSERT wiki_articles + wiki_revisions(author_type='ai')
+       + wiki_article_source_usage rows (§5.1) + flip generation_status; emit feedback events (§4.11)
+```
+
+Zero-regression: no `model_ref` ⇒ today's behaviour.
+
+---
+
+## 3. Generation: bounded multi-pass (🟥 P0)
+
+**Why not single-shot:** translation-v3 proves the generator is blind to its own grounding violations; a
+verifier that can only *quarantine* is half a system. Wiki's contract is *harder* (synthesize vs preserve).
+
+| Pass | Model tier | What |
+|---|---|---|
+| 1. WRITE | prose (strong) | plan sections → grounded TipTap body; mark each claim `grounded` + cite-id |
+| Gate A. RULE-CHECK | none (free) | every `[n]` resolves to a real supplied passage; required sections present; drop/flag un-cited claims — the wiki analogue of v3 `verifier.py:62`; this is what *guarantees* grounding |
+| 2. VERIFY | verify (cheap) | `CanonVerifier` (injection/anachronism/regurgitation/contradiction) + `decide_auto_reject` |
+| 3. REVISE | prose (strong) | **only if** HIGH flags, **max 1 round**; re-write flagged sections only |
+
+Calibration copied from translation-v3 (`orchestrator.py:230,:300`): **LLM-flag demotion** (LLM-only flag never
+triggers a destructive rewrite) + **deterministic keep-if-improved** (accept revise only if the rule-count
+drops). Hard ceiling 1 round for MVP. NOT a multi-round loop.
+
+---
+
+## 4. Detailed design (generation)
+
+### 4.1 Retriever — in-process refactor 🟡
+Extract `search_book` body into `async def run_hybrid_search(...) -> RawSearchResponse`; public route becomes a
+wrapper. Wiki worker calls it directly — no HTTP/JWT/`not_indexed`. Params: `mode=hybrid`,
+`granularity=chapter`, `limit≈8–15`, **`rerank=true`** (cosine band [0.68,0.82] non-separable), gate on
+`relevance`, carry `location.blockIndex`.
+
+### 4.2 wiki-gen module (NEW `app/wiki/`) 🟡
+`context.py` (clone enrichment `assembly.py`) · `sanitize.py` (LE `clients/sanitize.py:56`) 🟥 ·
+`prompt.py` (BookProfile-shaped; LE `generate.py:114-187`) · `generate.py` (LE `complete.py` + grounded-flag
+`generate.py:190-230`) · `rulegate.py` (v3 `verifier.py:62`) 🟧 · `revise.py` (v3 `corrector.py:44`) ·
+`cite.py` (SDK `cites.py:92`) · `verify.py` (LE `wiring.py:92-139`) · `fingerprint.py` (build_inputs hash, §5.1) 🟥 ·
+`runner.py` (LE `runner.py:149` + skip-done `:200-205`) · `cost.py` (knowledge `jobs/budget.py:48`) ·
+`consumer.py` (LE `resume_consumer.py:138-193`) 🟧 · `eval/` (knowledge `app/benchmark/metrics.py`) 🟩.
+**Transport = async-job** (`submit_and_wait` — retry yes, cost-cap is the job layer not the SDK).
+**Trigger = direct internal HTTP** (mirror `fetchWikiNeighborhood`).
+
+### 4.3 Prompt + output contract 🟡 (✅ closes language open-Q)
+- **BookProfile-shaped** 🟧: interpolate `worldview / voice / era_policy / language` into the prompt;
+  `profile.language` decides generation language (Chinese-only renderer was the de-bias bug). Unset →
+  `NEUTRAL_PROFILE`. *Caveat:* profile table lives in lore-enrichment; resolve cross-service in PLAN.
+- **Copyright guard at gen time** 🟧: "**synthesize in your own words; do not copy source phrasing**" — note it
+  fights the cite-everything instruction (raises regurgitation LCS); auto-reject wholesale copy only.
+- **Structural cite-enforcement** 🟧: grounded-flag protocol — un-cited claims dropped at parse; zero grounded →
+  skip entity (actionable reason, no hollow stub). Mirror `provenance.py:268-319`.
+- **Output:** TipTap `doc` (FE renderer unchanged) + references list + inline `[n]` anchored to `blockIndex`
+  (reuses raw-search `?block=N`). Enriched/KG facts keep H0 `source_type` marker.
+
+### 4.4 Security: injection sanitize 🟥 P0
+Raw passages → prompt is the **highest-risk injection surface**. Sanitize passages + attrs + KG **before**
+prompting (`neutralize_injection`, LE `sanitize.py:56`); `_safe()`-wrap writeback fields (LE `writeback.py:84`).
+
+### 4.5 Verification gate 🔒
+`CanonVerifier(canon_lookup, anachronism_markers=book_profile.anachronism_markers)`. Port `decide_auto_reject`
+(`wiring.py:92-139`): injection / HIGH-contradiction / ≥2 anachronism / HIGH-regurgitation → persist but
+`publish_blocked=true` + flags. `verify_degraded` ⇒ `passed=False`. Publish-block **server-enforced**.
+
+### 4.6 Writeback endpoint + clobber guard (NEW, Go) 🟥 P0
+`POST /internal/books/{book_id}/wiki/articles`. **`entity_id` is UNIQUE** (`migrate.go:562`) → blind insert
+throws on re-run; blind `ON CONFLICT … UPDATE` clobbers human edits. Rules: (1) upsert-by-entity with
+`SELECT … FOR UPDATE` (`wiki_handler.go:490`); (2) **human-edit guard** — AI overwrites ONLY untouched
+`author_type='ai'` `draft`; if `published` or any owner/human revision → land as **`wiki_suggestion`**
+(`migrate.go:599`); (3) retry-idempotent (no-op if `body_json` unchanged, `wiki_handler.go:458`); (4) stamp
+`author_type='ai'` + provenance; (5) transactional per article + write `wiki_article_source_usage` rows (§5.1).
+
+### 4.7 Trigger · job-state · resume 🟧 P1
+202 handshake + **durable Redis-stream** trigger (clone `resume_consumer.py`, NOT `asyncio.create_task`).
+Job SSOT = new `wiki_gen_jobs` table in knowledge-service (mirror `extraction_jobs`; reuse `state_machine.py`;
+states incl. `paused`). **FE polls the job row** as truth; glossary `generation_status` is an advisory mirror
+(fixes the failure-mirror: worker failure → job row carries it, glossary not stuck `pending`). **Skip-done
+before spend** (`runner.py:200-205`); **Regenerate = `force=true`** bypasses skip-done, routes through §4.6
+guard. Per-entity writeback retried; one bad entity ≠ abort batch.
+
+### 4.8 Cost-cap pause/resume 🟥 P0
+Knowledge `jobs/budget.py` (`can_start_job` preflight + `try_spend` + `record_spending`) + LE charge-before /
+reconcile-after (`cost.py:75-132` + `runner.py:419-432`). Breach → `paused` (work preserved), resumable.
+
+### 4.9 Model routing 🟧 P1 (✅ answers cost open-Q)
+Optional `step_models = { prose_model_ref?, verify_model_ref? }`, nullable fall-through to `model_ref`
+(`orchestrator.py:209`). Cheap verify / strong prose. Tiered routing = the cost lever. Reasoning =
+`reasoning_effort` **pass-through** only; no wiki reasoning classifier for MVP.
+
+### 4.10 Schema changes 🟡
+**`wiki_articles`** add: `generation_status TEXT DEFAULT 'none'` (`none|pending|generated|failed`),
+`generated_by TEXT`, `generation_provenance JSONB` (incl. **`build_inputs`** fingerprint, §5.1, +
+`citations`, `verify_flags`, `publish_blocked`, `grounding`, `step_models`), `generated_at TIMESTAMPTZ`,
+**`is_knowledge_stale BOOLEAN DEFAULT false`** (denormalized flag, §5.2).
+**`wiki_revisions.author_type`** — allow `'ai'`; migrate deterministic-stub author `'owner'`→`'system'` so
+"human-touched" is detectable.
+**NEW `wiki_article_source_usage(article_id, source_type, source_id, source_version, PRIMARY KEY(article_id,
+source_type,source_id))`** — reverse dependency index (§5.1), the `chapter_translation_glossary_usage` analogue.
+**NEW `wiki_staleness(staleness_id, article_id, reason_code, source_ref JSONB, severity, detected_at,
+status DEFAULT 'pending')`** — the deferred change ledger (§5.2).
+**NEW `wiki_gen_jobs`** (knowledge-service) — job SSOT incl. `paused`.
+Change FK `wiki_articles.entity_id` **`ON DELETE CASCADE` → `ON DELETE RESTRICT`** (§5.5).
+
+### 4.11 Feedback learning loop 🟩 (MVP = emit)
+Wiki already stores the gold translation had to build — `wiki_revisions` (AI-draft→human-edit pairs) +
+accept/reject `wiki_suggestions`. Emit `wiki.corrected` (from `patchWikiArticle` when prior revision was
+`author_type='ai'` + owner edits) + `wiki.suggestion_reviewed` via glossary's outbox → learning-service
+`corrections` + `quality_scores` (`target_kind='wiki_article'`). **Follow-up:** consume gold as few-shot in
+`prompt.py`.
+
+### 4.12 Quality eval harness 🟩 (MVP = thin advisory)
+`app/benchmark/wiki/` over a ~15-entity Fengshen golden: **citation-resolvability** + **verify-flag-rate**
+(GROUP BY over `generation_provenance` — zero new code) deterministic → advisory CI band; **coverage**
+(`recall_at_k`); **groundedness** (LLM-judge + discrimination probe) = follow-up.
+
+### 4.13 Frontend (`features/wiki`) 🟡
+Model picker (+ optional per-step) + deterministic/LLM toggle. Poll **job row** for batch progress.
+Article view: citations + "jump to source", **"AI-generated · unverified"** badge + verify flags,
+**Regenerate** (`force=true`). **NEW (phase-2): "outdated vs current knowledge" badge** (driven by
+`is_knowledge_stale`) + a **"Knowledge updates" change-feed** (§5.3) — stale articles grouped by the knowledge
+change that caused them (chapter re-publish / attr edit / merge / broken citation / recipe upgrade), each with
+what-changed + severity (🔴 hard-broken-citation / 🟡 structural / 🔵 content), **batch-select → cost-estimate →
+cost-capped regenerate**; human-edited articles route to suggestion not overwrite; the deferred banner makes
+clear nothing regenerates until the user acts. AI-as-suggestion shows when the clobber-guard routes a regen to
+review.
+
+**Mockup:** all FE states (reader · generate dialog · job progress · suggestions · **change-feed**) are
+prototyped in `docs/specs/2026-06-08-wiki-llm-building-mockup.html` (5 switchable screens, theme-faithful).
+
+---
+
+## 5. Change-Control: wiki as a deferred-sync materialized view 🟦
+
+PO policy: **(1) not realtime CDC — capture, defer the work in a DB ledger; (2) regeneration costs tokens → the
+user decides.** Three stages — *capture* (cheap, auto, **MVP**) → *defer* (ledger, no work, phase-2) → *decide*
+(user-gated, phase-2) — plus entity-lifecycle propagation. Every staleness precedent in the repo
+(`translation`, `stale-image-guard`, `enrichment`) independently lands on **flag-don't-auto-rebuild**.
+
+### 5.1 CAPTURE — dependency fingerprint + reverse usage-index (🟥 MVP, mandatory)
+**Why MVP even though reaction is phase-2:** you cannot reconstruct "what knowledge an article was built from"
+after the fact — same logic as emitting feedback events in MVP. The generation worker, at writeback, records:
+
+- **`wiki_article_source_usage`** rows — every input the article actually consumed: each `entity_id` (self +
+  KG neighbors used), each cited `(chapter_id, block_index)`. The `chapter_translation_glossary_usage` analogue
+  (`translation/app/migrate.py:299`).
+- **`generation_provenance.build_inputs`** fingerprint (hash with ported learning `_stable_hash`):
+  `{ schema_version, entity_id, entity_revision_num, entity_content_hash, attr_set_hash, kg_neighborhood_hash,
+  cited_blocks:[{chapter_id, block_index, content_hash}], retrieval_params_hash, model_ref, prompt_version,
+  pipeline_version }`. Sources of each token already exist: `entity_revisions.revision_num` (monotonic, clock-
+  skew-immune), `chapter_blocks.content_hash` (book-service), the glossary `entity_snapshot`.
+
+This is the *only* change-control work in MVP — it is data capture, no reaction logic. Cheap, additive.
+
+### 5.2 DEFER — staleness ledger, NOT realtime CDC (🟦 phase-2)
+Capture change into the **`wiki_staleness` ledger**; do **zero** LLM work. Two feeds, both lightweight:
+
+- **Push — a lightweight `wiki-staleness` consumer group** on `loreweave:events:{glossary,chapter}` (clone
+  `translation/app/events/glossary_consumer.py`: forward-only `id="$"` so first deploy doesn't replay ~200k
+  events; idempotent; bounded-retry-ack; **no-false-negative fallback** — an article with no usage rows gets a
+  coarse book-level flag). On an event it **joins `wiki_article_source_usage`** and, for each affected article,
+  upserts a `wiki_staleness` row (`reason_code`, `source_ref`, `severity`) + flips `is_knowledge_stale=true`.
+  **It never regenerates.** Signals subscribed:
+  - `glossary.entity_updated` (covers attr/name/short_description **and** enrichment promote/retract) → article
+    of that entity stale (reason `entity_attr_changed` / `name_changed` / `enrichment_changed`).
+  - `glossary.entity_merged` → loser article → `merged` (redirect, §5.4); winner article stale.
+  - `chapter.published/unpublished/deleted` → join cited `chapter_id` → `chapter_regrounded` (drifted) or
+    `citation_broken` (hard — block no longer canon).
+- **Pull — a periodic fingerprint sweep** (nightly / on-demand) recomputes `build_inputs` vs current knowledge
+  for a slice and writes ledger rows for drift the events can't cover: pipeline-driven **KG changes emit nothing**
+  (the catalog's GAP A — neighbor re-extraction); and **`prompt_version`/`pipeline_version` bumps** = same-input
+  recipe drift (the stale-image-guard §6b lesson — version-hash can't catch behavioral drift, so make it an
+  explicit token). The sweep is the authoritative tier-2; events are the responsive tier-1.
+
+> Because it is **not realtime**, the live consumer is itself optional for a first cut — a pure periodic sweep is
+> a valid simpler start; the consumer is the latency upgrade. Either way the ledger is the single deferred queue.
+
+**Severity (from learning `split_snapshot`):** `kind` change = **structural** (frame wrong → strongly suggest
+regen); `short_description`/attr tweak = **content** (soft, advisory); broken citation = **hard** (cite points
+at non-canon). Severity drives how loudly the UI nudges, never auto-action.
+
+### 5.3 DECIDE — user-gated update (🟦 phase-2; token cost is the reason)
+Regeneration is **never automatic**. A **"Knowledge updates" surface** drains the ledger:
+- Lists stale articles grouped by reason ("3 bài outdated — 妲己: chương 23 tái-publish · 姜子牙: sửa attr · …"),
+  each with a "what changed" diff and the staleness severity.
+- User **selects / batches** → **cost estimate** (N × ~tokens) → confirm → enqueues a regenerate job (the §4.7
+  pipeline, `force=true`) → **cost-capped + pause/resume + skip-done** (§4.8/4.7). On completion the ledger rows
+  resolve (`status='regenerated'`) and `is_knowledge_stale` clears.
+- **Clobber-guard respected:** a stale article that is human-edited → regen lands as a **suggestion** diff, never
+  an overwrite (§4.6).
+- **Free floor may auto-refresh:** the deterministic `renderWikiBody` is free + deterministic, so cheap changes
+  (e.g. rename) MAY re-render it synchronously; only **LLM** regeneration is user-gated. User can also "dismiss"
+  a staleness row (accept-as-is) — it resolves without spend.
+
+### 5.4 Entity-lifecycle propagation 🟦
+Split: **structural integrity = immediate** in the write tx (free/cheap; about not losing data); **expensive
+body regen = deferred** to the ledger (user-gated). Copy the proven enrichment pattern (repoint + union +
+journal, in the same `mergeOne` tx).
+
+- **MERGE** — *immediately*: union loser's `wiki_revisions` onto winner (re-number versions), journal the moved
+  PKs + a snapshot of the deleted loser article (for un-merge), leave a **redirect** (read-path resolves a
+  merged loser's article → winner, using `merged_into_entity_id`). *Deferred*: mark winner `is_knowledge_stale`
+  (reason `merged`) → ledger; body regenerates from the merged context when the user decides. **Fixes the
+  silent-abandon data-loss bug (§5.5).**
+- **RENAME** — title/infobox auto-follow (read-time derivation, already correct — do **not** add a title
+  column). Deterministic body re-renders free; LLM body → ledger row (`name_changed`).
+- **DELETE (soft)** — article hibernates with its entity (already reversible). Fix the detail-serves-soft-deleted
+  inconsistency (`loadWikiArticleDetail` lacks the `deleted_at` filter, `wiki_handler.go:1114`).
+- **UN-MERGE** — journal-restore the loser's human revisions; mark **both** articles stale → bodies regenerate
+  (deferred) the way the KG reconverges (it no-ops un-merge and re-derives). Human revisions are journal-restored
+  (not derivable); the body is regenerated (derivable).
+
+### 5.5 Two pre-existing data-loss bugs (🟥 fix before/with MVP — the body is now the product)
+1. **Merge abandons the loser's article** (`merge_handler.go:305`: repoints only if winner has none; else the
+   loser's article + revisions are silently orphaned on a soft-deleted row). Contradicts the merge spec's own
+   AC4. Under the LLM design the body is the product (no Neo4j copy to re-derive) → this is real data loss.
+   **Fix:** revision-union + redirect (§5.4).
+2. **`ON DELETE CASCADE` on a product table** (`migrate.go:562`): deleting a *kind* (`kinds_crud.go:225`)
+   hard-deletes its entities and **silently destroys** their `wiki_articles` + revisions + suggestions, no
+   count, no warning. **Fix:** FK → `ON DELETE RESTRICT`; purge / kind-delete must explicitly archive + emit
+   `wiki.deleted` (so the feedback loop captures the gold first) before deleting.
+
+---
+
+## 6. Failure modes
+
+| Condition | Behaviour |
+|---|---|
+| `model_ref` absent | Deterministic `renderWikiBody` (floor). |
+| Provider/LLM down | Job `failed` (job row); FE offers deterministic fallback. |
+| Cost cap breached 🟥 | Job `paused`, work preserved; resumes skip-done. |
+| Book not indexed | Semantic leg empty → grounding degrades to lexical+KG+attrs; hint. |
+| Zero grounded claims 🟧 | **Skip** entity with actionable reason (no hollow article). |
+| Verify auto-reject | Persist `draft` + `publish_blocked` (server-enforced) + flags; human review. |
+| Re-run / regenerate 🟥 | Upsert-by-entity; clobber-guard → refresh untouched ai-draft, else `wiki_suggestion`. |
+| Worker crash mid-batch 🟧 | Stream redelivery → resume from skip-done cursor. |
+| **Knowledge changed** 🟦 | Captured to `wiki_staleness` ledger + `is_knowledge_stale` flag. **No regeneration** until the user decides. |
+| **Staleness consumer down** 🟦 | Periodic fingerprint sweep backstops it; ledger is eventually-consistent, not realtime (by design). |
+| **Entity merged/renamed/deleted** 🟦 | Structural integrity immediate (revision-union/redirect/restrict); body regen deferred to ledger. |
+
+---
+
+## 7. Testing
+
+- **Unit:** prompt builder (BookProfile), TipTap parser, rule-gate, revise keep-if-improved, sanitize,
+  clobber-guard branches, cost charge/reconcile, skip-done, **build_inputs fingerprint determinism**, **staleness
+  join (event → affected articles)**, **merge revision-union + redirect**.
+- **Cross-service live-smoke (REQUIRED — ≥4 services):** real generation on Fengshen through
+  glossary→knowledge→provider-registry→book-service; assert grounded body + citations→real block_index + draft
+  writeback + **re-run routes to suggestion not clobber** + **source_usage rows written**. First live
+  `compose_cites` consumer → real-passage smoke. **Phase-2:** edit an attr → assert the article's ledger row
+  appears + flag flips + **no LLM call fired** (deferral proven); merge two entities → assert loser revisions
+  preserved on winner + redirect resolves.
+- **Eval harness** (§4.12) advisory band.
+
+---
+
+## 8. Rollout & phasing
+
+Opt-in by `model_ref` ⇒ zero regression. Ships in phases:
+
+- **Phase 1 (MVP) — generation + capture.** Bounded multi-pass + all P0/P1 hardening + feedback-emit + thin
+  eval + **§5.1 dependency capture (mandatory — cannot retrofit)** + **§5.5 bug fixes** (data-loss, do early).
+  Output: the wiki can generate grounded articles and *records what each was built from*. No staleness reaction
+  yet — but the data to react is being captured from day 1.
+- **Phase 2 — change-control reaction.** §5.2 ledger + (sweep and/or consumer) · §5.3 user-gated "Knowledge
+  updates" surface · §5.4 entity-lifecycle body-regen · §4.13 stale badge. All user-gated, cost-capped.
+- **Follow-up.** Consume feedback gold as few-shot · judge-based eval · §5.2 precise KG-edge events (net-new
+  `knowledge.kg_synced` emit) if the sweep proves too coarse.
+
+---
+
+## 9. Resolved-by-review
+1. ✅ **Generation language** → `BookProfile.language`. 2. ✅ **Multi-pass vs single** → multi-pass IS MVP.
+3. ✅ **Cost/batch** → `budget.py` cap + pause/resume + tiered routing; **regeneration user-gated (§5.3).**
+4. ✅ **Index prerequisite** → degrade + hint. 5. ✅ **Model selection** → picker + per-step override.
+6. ✅ **Realtime vs deferred staleness** → **deferred ledger, not CDC** (PO). 7. ✅ **Auto vs manual update** →
+**user-decides, token-cost-gated** (PO).
+
+## 10. Explicitly NOT copied (avoid over-engineering)
+TransAgents many-role company (3 passes ceiling) · multi-round loop / self-consistency (1 revise) · rolling-
+summary stitch · sub-article checkpoints · auto-reasoning classifier (pass-through only) · enrichment eval-gate
+/strategy-factory · KG-write half of enrichment writeback (wiki read-only KG) · redundant ownership re-check ·
+**realtime CDC / auto-regeneration** (deferred + user-gated by design). Wiki correctly differs: SDK
+`GroundingCite` (clean first consumer, advances D-063) · own TipTap output contract · title read-time-derived
+(no title column).
+
+## 11. Deferred / watch
+- `compose_cites` first live use → real-passage smoke (VERIFY gate).
+- Cross-service `BookProfile` access (knowledge ↔ lore-enrichment table) — resolve in PLAN.
+- `D-GROUNDING-COMPOSE-MIGRATE` (063): wiki adopting `GroundingCite` informs the enrichment migration.
+- Precise KG-edge invalidation: only if the §5.2 chapter-proxy sweep proves too coarse → add
+  `knowledge.kg_synced` emit (net-new plumbing, follow-up).
+- Recycle-bin GC (does not exist yet): when built, must NOT rely on CASCADE — explicit archive + `wiki.deleted`.

--- a/services/glossary-service/internal/api/kind_aliases_test.go
+++ b/services/glossary-service/internal/api/kind_aliases_test.go
@@ -43,7 +43,22 @@ func newKindAliasServer(t *testing.T, pool *pgxpool.Pool) *Server {
 func runKindAliasMigrations(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	runK2aMigrations(t, pool)
-	if err := migrate.SeedKindAliases(context.Background(), pool); err != nil {
+	ctx := context.Background()
+	// deleteKind now reads wiki_articles + writes the wiki.deleted outbox row
+	// (Bug-2 fix) — bring those tables up too.
+	for _, m := range []struct {
+		name string
+		fn   func(context.Context, *pgxpool.Pool) error
+	}{
+		{"UpOutbox", migrate.UpOutbox},
+		{"UpWiki", migrate.UpWiki},
+		{"UpWikiSuggestions", migrate.UpWikiSuggestions},
+	} {
+		if err := m.fn(ctx, pool); err != nil {
+			t.Fatalf("migrate.%s: %v", m.name, err)
+		}
+	}
+	if err := migrate.SeedKindAliases(ctx, pool); err != nil {
 		t.Fatalf("migrate.SeedKindAliases: %v", err)
 	}
 }
@@ -350,8 +365,33 @@ func TestDeleteKind_BlocksActiveButPurgesSoftDeleted(t *testing.T) {
 	if _, err := pool.Exec(ctx, `UPDATE glossary_entities SET deleted_at=now() WHERE entity_id=$1`, eid); err != nil {
 		t.Fatalf("soft-delete entity (sql): %v", err)
 	}
-	if w := userReq(t, srv, http.MethodDelete, "/v1/glossary/kinds/"+ck.KindID, ""); w.Code != http.StatusNoContent {
-		t.Fatalf("delete kind with only soft-deleted entities: want 204, got %d (%s)", w.Code, w.Body.String())
+	// Bug-2 fix: give the soft-deleted entity a wiki_article (a product). With the
+	// entity FK now RESTRICT, deleteKind must delete it EXPLICITLY (not FK-block),
+	// surface a count, and emit wiki.deleted — instead of the prior silent CASCADE.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO wiki_articles (entity_id, book_id, body_json, status) VALUES ($1,$2,'{}','draft')`,
+		eid, book); err != nil {
+		t.Fatalf("seed wiki article: %v", err)
+	}
+	w := userReq(t, srv, http.MethodDelete, "/v1/glossary/kinds/"+ck.KindID, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete kind: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var delResp struct {
+		DeletedWikiArticles int `json:"deleted_wiki_articles"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &delResp)
+	if delResp.DeletedWikiArticles != 1 {
+		t.Errorf("deleted_wiki_articles = %d, want 1 (article must be deleted explicitly, not silently)", delResp.DeletedWikiArticles)
+	}
+	var nEvent, nArt int
+	pool.QueryRow(ctx, `SELECT count(*) FROM outbox_events WHERE event_type='wiki.deleted' AND payload->>'entity_id'=$1`, eid).Scan(&nEvent)
+	if nEvent != 1 {
+		t.Errorf("wiki.deleted events for entity = %d, want 1 (destruction must be observable)", nEvent)
+	}
+	pool.QueryRow(ctx, `SELECT count(*) FROM wiki_articles WHERE entity_id=$1`, eid).Scan(&nArt)
+	if nArt != 0 {
+		t.Errorf("wiki article not deleted (%d remain)", nArt)
 	}
 	var kindRows, entRows int
 	pool.QueryRow(ctx, `SELECT count(*) FROM entity_kinds WHERE kind_id=$1`, ck.KindID).Scan(&kindRows)

--- a/services/glossary-service/internal/api/kinds_crud.go
+++ b/services/glossary-service/internal/api/kinds_crud.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/loreweave/glossary-service/internal/domain"
@@ -222,6 +224,58 @@ func (s *Server) deleteKind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer tx.Rollback(r.Context())
+
+	// Bug-2 fix: wiki_articles is a product table; the entity FK is now RESTRICT
+	// (no silent cascade). Explicitly delete the articles of the soft-deleted
+	// entities being purged — emitting wiki.deleted per article (observable) and
+	// surfacing a count — BEFORE deleting the entities (else RESTRICT FK-blocks).
+	type delArt struct{ articleID, entityID, bookID uuid.UUID }
+	var deletedArts []delArt
+	artRows, err := tx.Query(r.Context(), `
+		SELECT wa.article_id, wa.entity_id, wa.book_id
+		FROM wiki_articles wa
+		JOIN glossary_entities ge ON ge.entity_id = wa.entity_id
+		WHERE ge.kind_id=$1 AND ge.deleted_at IS NOT NULL`, kindID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "GLOSS_INTERNAL", "gather wiki articles failed")
+		return
+	}
+	for artRows.Next() {
+		var a delArt
+		if err := artRows.Scan(&a.articleID, &a.entityID, &a.bookID); err != nil {
+			artRows.Close()
+			writeError(w, http.StatusInternalServerError, "GLOSS_INTERNAL", "scan wiki articles failed")
+			return
+		}
+		deletedArts = append(deletedArts, a)
+	}
+	artRows.Close()
+	if err := artRows.Err(); err != nil {
+		writeError(w, http.StatusInternalServerError, "GLOSS_INTERNAL", "gather wiki articles failed")
+		return
+	}
+	exec := func(ctx context.Context, sql string, args ...any) error {
+		_, e := tx.Exec(ctx, sql, args...)
+		return e
+	}
+	for _, a := range deletedArts {
+		// wiki_revisions + wiki_suggestions cascade off article_id (intended; wiki-internal).
+		if _, err := tx.Exec(r.Context(), `DELETE FROM wiki_articles WHERE article_id=$1`, a.articleID); err != nil {
+			writeError(w, http.StatusInternalServerError, "GLOSS_INTERNAL", "delete wiki article failed")
+			return
+		}
+		if err := insertWikiDeletedOutboxEvent(r.Context(), exec, a.articleID, wikiDeletedPayload{
+			BookID:    a.bookID.String(),
+			ArticleID: a.articleID.String(),
+			EntityID:  a.entityID.String(),
+			Reason:    "kind_deleted",
+			EmittedAt: time.Now().UTC().Format(time.RFC3339),
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, "GLOSS_INTERNAL", "emit wiki.deleted failed")
+			return
+		}
+	}
+
 	if _, err := tx.Exec(r.Context(),
 		`DELETE FROM glossary_entities WHERE kind_id=$1 AND deleted_at IS NOT NULL`, kindID,
 	); err != nil {
@@ -239,7 +293,8 @@ func (s *Server) deleteKind(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "GLOSS_INTERNAL", "tx commit failed")
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	// Bug-2: surface the count of destroyed articles (was 204 No Content — silent).
+	writeJSON(w, http.StatusOK, map[string]any{"deleted_wiki_articles": len(deletedArts)})
 }
 
 // createAttrDef handles POST /v1/glossary/kinds/{kind_id}/attributes

--- a/services/glossary-service/internal/api/merge_handler.go
+++ b/services/glossary-service/internal/api/merge_handler.go
@@ -302,17 +302,34 @@ func (s *Server) mergeOne(
 	if err != nil {
 		return uuid.Nil, "", err
 	}
-	// wiki: move loser's article only if the winner has none (UNIQUE(entity_id)).
-	wiki, err := scanUUIDs(ctx, tx, `
-		UPDATE wiki_articles SET entity_id = $1
+	// wiki (Bug-1 fix, merge-spec AC4): repoint the loser's article to the winner
+	// when the winner has NONE. When BOTH have an article, the loser's is ARCHIVED
+	// in place (superseded_by_entity_id := winner) — kept, revision-preserved, and
+	// resolvable via redirect — never silently abandoned. Bodies are NOT auto-merged
+	// (the winner's stays canonical; merge-and-regenerate is later wiki-LLM work).
+	var wikiArticle, supersededWiki *uuid.UUID
+	wikiRepoint, err := scanUUIDs(ctx, tx, `
+		UPDATE wiki_articles SET entity_id = $1, updated_at = now()
 		WHERE entity_id = $2 AND NOT EXISTS (SELECT 1 FROM wiki_articles WHERE entity_id = $1)
 		RETURNING article_id`, winnerID, loserID)
 	if err != nil {
 		return uuid.Nil, "", err
 	}
-	var wikiArticle *uuid.UUID
-	if len(wiki) == 1 {
-		wikiArticle = &wiki[0]
+	if len(wikiRepoint) == 1 {
+		wikiArticle = &wikiRepoint[0]
+	} else {
+		// repoint was a no-op → either the loser has no article (nothing to do) or
+		// BOTH have one → archive the loser's in place, pointing at the winner.
+		wikiArchive, aerr := scanUUIDs(ctx, tx, `
+			UPDATE wiki_articles SET superseded_by_entity_id = $1, updated_at = now()
+			WHERE entity_id = $2 AND superseded_by_entity_id IS NULL
+			RETURNING article_id`, winnerID, loserID)
+		if aerr != nil {
+			return uuid.Nil, "", aerr
+		}
+		if len(wikiArchive) == 1 {
+			supersededWiki = &wikiArchive[0]
+		}
 	}
 
 	// 2. Fold loser name + aliases into the winner's aliases (anti-resurrection:
@@ -364,9 +381,9 @@ func (s *Server) mergeOne(
 		INSERT INTO merge_journal
 		  (book_id, winner_entity_id, loser_entity_id, repointed_chapter_link_ids,
 		   repointed_eav_ids, repointed_enrichment_ids, repointed_audit_ids,
-		   repointed_wiki_article_id, winner_aliases_before, merged_by)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING journal_id`,
-		bookID, winnerID, loserID, chLinks, eavs, enrich, audit, wikiArticle, aliasesBefore, actor,
+		   repointed_wiki_article_id, superseded_wiki_article_id, winner_aliases_before, merged_by)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) RETURNING journal_id`,
+		bookID, winnerID, loserID, chLinks, eavs, enrich, audit, wikiArticle, supersededWiki, aliasesBefore, actor,
 	).Scan(&journalID); err != nil {
 		return uuid.Nil, "", err
 	}
@@ -427,15 +444,16 @@ func (s *Server) revertMergeCore(ctx context.Context, bookID, journalID uuid.UUI
 		chLinks, eavs     []uuid.UUID
 		enrich, audit     []uuid.UUID
 		wikiArticle       *uuid.UUID
+		supersededWiki    *uuid.UUID
 		aliasesBefore     *string
 		status            string
 	)
 	if err := s.pool.QueryRow(ctx, `
 		SELECT book_id, winner_entity_id, loser_entity_id, repointed_chapter_link_ids,
 		       repointed_eav_ids, repointed_enrichment_ids, repointed_audit_ids,
-		       repointed_wiki_article_id, winner_aliases_before, status
+		       repointed_wiki_article_id, superseded_wiki_article_id, winner_aliases_before, status
 		FROM merge_journal WHERE journal_id = $1`, journalID,
-	).Scan(&jBook, &winnerID, &loserID, &chLinks, &eavs, &enrich, &audit, &wikiArticle, &aliasesBefore, &status); err != nil {
+	).Scan(&jBook, &winnerID, &loserID, &chLinks, &eavs, &enrich, &audit, &wikiArticle, &supersededWiki, &aliasesBefore, &status); err != nil {
 		return "not_found", nil
 	}
 	if jBook != bookID {
@@ -476,6 +494,13 @@ func (s *Server) revertMergeCore(ctx context.Context, bookID, journalID uuid.UUI
 	}
 	if wikiArticle != nil {
 		if _, err := tx.Exec(ctx, `UPDATE wiki_articles SET entity_id=$1 WHERE article_id=$2`, loserID, *wikiArticle); err != nil {
+			return "", err
+		}
+	}
+	// Un-archive a superseded loser article (Bug-1 fix): clear the redirect so the
+	// restored loser entity's article is live again.
+	if supersededWiki != nil {
+		if _, err := tx.Exec(ctx, `UPDATE wiki_articles SET superseded_by_entity_id=NULL, updated_at=now() WHERE article_id=$1`, *supersededWiki); err != nil {
 			return "", err
 		}
 	}

--- a/services/glossary-service/internal/api/merge_handler_test.go
+++ b/services/glossary-service/internal/api/merge_handler_test.go
@@ -56,6 +56,20 @@ func newMergeFixture(t *testing.T, bookSuffix string) *mergeFixture {
 	srv.pool = pool
 	f.srv = srv
 	pool.QueryRow(ctx, `SELECT kind_id FROM entity_kinds WHERE code='character' LIMIT 1`).Scan(&f.kindID)
+	// migrate.Seed only seeds default kinds when entity_kinds is EMPTY; on a shared
+	// test DB a prior test (e.g. the 'unknown' park kind) makes it skip, leaving
+	// 'character' absent. Seed it order-independently so the fixture is robust.
+	if f.kindID == uuid.Nil {
+		pool.Exec(ctx, `INSERT INTO entity_kinds(code,name,icon,color,is_default,is_hidden,sort_order)
+			SELECT 'character','Character','user','#888888',true,false,0
+			WHERE NOT EXISTS (SELECT 1 FROM entity_kinds WHERE code='character')`)
+		pool.QueryRow(ctx, `SELECT kind_id FROM entity_kinds WHERE code='character' LIMIT 1`).Scan(&f.kindID)
+		for _, a := range []struct{ code, name string }{{"name", "Name"}, {"aliases", "Aliases"}, {"description", "Description"}} {
+			pool.Exec(ctx, `INSERT INTO attribute_definitions(kind_id,code,name,field_type,is_required,is_system,sort_order)
+				SELECT $1,$2,$3,'text',false,true,0
+				WHERE NOT EXISTS (SELECT 1 FROM attribute_definitions WHERE kind_id=$1 AND code=$2)`, f.kindID, a.code, a.name)
+		}
+	}
 	pool.QueryRow(ctx, `SELECT attr_def_id FROM attribute_definitions WHERE kind_id=$1 AND code='name' LIMIT 1`, f.kindID).Scan(&f.nameAttr)
 	pool.QueryRow(ctx, `SELECT attr_def_id FROM attribute_definitions WHERE kind_id=$1 AND code='aliases' LIMIT 1`, f.kindID).Scan(&f.aliasAttr)
 	pool.QueryRow(ctx, `SELECT attr_def_id FROM attribute_definitions WHERE kind_id=$1 AND code='description' LIMIT 1`, f.kindID).Scan(&f.descAttr)

--- a/services/glossary-service/internal/api/outbox.go
+++ b/services/glossary-service/internal/api/outbox.go
@@ -80,6 +80,44 @@ func insertMergedOutboxEvent(
 	return nil
 }
 
+// wikiDeletedEvent (Bug-2 fix) is emitted when a wiki article is destroyed —
+// either by the owner deleting it (deleteWikiArticle) or by a kind-delete purging
+// soft-deleted entities. Emitting it makes the destruction OBSERVABLE (vs the
+// prior silent ON DELETE CASCADE) and lets a future learning-loop capture the
+// article before it is gone. aggregate_id is the article_id.
+const wikiDeletedEvent = "wiki.deleted"
+
+type wikiDeletedPayload struct {
+	BookID    string `json:"book_id"`
+	ArticleID string `json:"article_id"`
+	EntityID  string `json:"entity_id"`
+	Reason    string `json:"reason"` // "user_deleted" | "kind_deleted"
+	EmittedAt string `json:"emitted_at"`
+}
+
+// insertWikiDeletedOutboxEvent writes a wiki.deleted outbox row. Generic over
+// pool/tx via the exec closure; best-effort at the call site (the delete has /
+// will commit; a missed event is tolerable, never blocks the delete).
+func insertWikiDeletedOutboxEvent(
+	ctx context.Context,
+	exec func(ctx context.Context, sql string, args ...any) error,
+	articleID uuid.UUID,
+	payload wikiDeletedPayload,
+) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("wiki.deleted outbox marshal: %w", err)
+	}
+	if err := exec(ctx, `
+		INSERT INTO outbox_events (aggregate_type, aggregate_id, event_type, payload)
+		VALUES ('glossary', $1, $2, $3)`,
+		articleID, wikiDeletedEvent, payloadJSON,
+	); err != nil {
+		return fmt.Errorf("wiki.deleted outbox insert: %w", err)
+	}
+	return nil
+}
+
 // entityEventPayload is the JSON payload carried by glossary.entity_updated.
 //
 // It is self-sufficient: it carries everything knowledge-service's

--- a/services/glossary-service/internal/api/wiki_dataloss_test.go
+++ b/services/glossary-service/internal/api/wiki_dataloss_test.go
@@ -1,0 +1,228 @@
+package api
+
+// Bug-fix DB-integration tests (data-loss guards) preceding the wiki-LLM feature.
+//   Bug 1 — merge must NOT silently abandon a loser's wiki_article (merge AC4):
+//           both sides have an article  -> loser's archived in place (superseded_by
+//                                          -> winner), winner's untouched;
+//           only the loser has one      -> repointed to winner (unchanged);
+//           un-merge                    -> archive cleared (round-trip lossless).
+//   Bug 2 — the wiki_articles entity FK is RESTRICT: a raw entity delete with an
+//           article must FK-block (no silent ON DELETE CASCADE destruction).
+// Reuse the merge fixture (newMergeFixture) — requires GLOSSARY_TEST_DB_URL; skips otherwise.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// mockBookOwner stands up a fake book-service projection endpoint so verifyBookOwner
+// passes for `owner`, and points the fixture's server at it. Returns the owner id.
+func mockBookOwner(t *testing.T, f *mergeFixture) string {
+	t.Helper()
+	owner := uuid.New().String()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"book_id": f.bookID.String(), "owner_user_id": owner,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	f.srv.cfg.BookServiceURL = srv.URL
+	return owner
+}
+
+func mkWikiArticle(t *testing.T, pool *pgxpool.Pool, ctx context.Context, bookID, entityID uuid.UUID) uuid.UUID {
+	t.Helper()
+	var aid uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO wiki_articles (entity_id, book_id, body_json, status) VALUES ($1,$2,'{}','draft') RETURNING article_id`,
+		entityID, bookID).Scan(&aid); err != nil {
+		t.Fatalf("mkWikiArticle: %v", err)
+	}
+	return aid
+}
+
+func wikiSupersededBy(t *testing.T, pool *pgxpool.Pool, ctx context.Context, articleID uuid.UUID) *uuid.UUID {
+	t.Helper()
+	var s *uuid.UUID
+	pool.QueryRow(ctx, `SELECT superseded_by_entity_id FROM wiki_articles WHERE article_id=$1`, articleID).Scan(&s)
+	return s
+}
+
+func wikiEntityOf(t *testing.T, pool *pgxpool.Pool, ctx context.Context, articleID uuid.UUID) uuid.UUID {
+	t.Helper()
+	var e uuid.UUID
+	pool.QueryRow(ctx, `SELECT entity_id FROM wiki_articles WHERE article_id=$1`, articleID).Scan(&e)
+	return e
+}
+
+// cleanupWikiArticles registers AFTER newMergeFixture so it runs BEFORE the
+// fixture's entity cleanup (LIFO) — with the FK now RESTRICT, deleting entities
+// while their articles exist would FK-block.
+func cleanupWikiArticles(t *testing.T, f *mergeFixture) {
+	t.Cleanup(func() { f.pool.Exec(f.ctx, `DELETE FROM wiki_articles WHERE book_id=$1`, f.bookID) })
+}
+
+// Bug 1: both sides have an article -> the loser's is archived (superseded_by ->
+// winner), never silently abandoned; the winner's stays live; journal records it.
+func TestMergeOne_BothHaveArticle_ArchivesLoser(t *testing.T) {
+	f := newMergeFixture(t, "00000000000a")
+	cleanupWikiArticles(t, f)
+	winner := f.mkEntity(t, "周文王", nil)
+	loser := f.mkEntity(t, "姬昌", nil)
+	winnerArt := mkWikiArticle(t, f.pool, f.ctx, f.bookID, winner)
+	loserArt := mkWikiArticle(t, f.pool, f.ctx, f.bookID, loser)
+
+	jid, reason, err := f.srv.mergeOne(f.ctx, f.bookID, winner, f.kindID, loser, uuid.New())
+	if err != nil || reason != "" {
+		t.Fatalf("mergeOne: reason=%q err=%v", reason, err)
+	}
+	if sb := wikiSupersededBy(t, f.pool, f.ctx, loserArt); sb == nil || *sb != winner {
+		t.Errorf("loser article not archived to winner (silent abandon?): got %v", sb)
+	}
+	if sb := wikiSupersededBy(t, f.pool, f.ctx, winnerArt); sb != nil {
+		t.Errorf("winner article wrongly superseded: %v", sb)
+	}
+	if e := wikiEntityOf(t, f.pool, f.ctx, loserArt); e != loser {
+		t.Errorf("loser article entity changed: got %v want %v", e, loser)
+	}
+	var jSuperseded *uuid.UUID
+	f.pool.QueryRow(f.ctx, `SELECT superseded_wiki_article_id FROM merge_journal WHERE journal_id=$1`, jid).Scan(&jSuperseded)
+	if jSuperseded == nil || *jSuperseded != loserArt {
+		t.Errorf("journal superseded_wiki_article_id = %v, want %v", jSuperseded, loserArt)
+	}
+}
+
+// Bug 1: only the loser has an article -> still repointed to the winner (unchanged
+// behaviour), NOT archived.
+func TestMergeOne_OnlyLoserHasArticle_Repoints(t *testing.T) {
+	f := newMergeFixture(t, "00000000000b")
+	cleanupWikiArticles(t, f)
+	winner := f.mkEntity(t, "姜子牙", nil)
+	loser := f.mkEntity(t, "太公望", nil)
+	loserArt := mkWikiArticle(t, f.pool, f.ctx, f.bookID, loser)
+
+	if _, reason, err := f.srv.mergeOne(f.ctx, f.bookID, winner, f.kindID, loser, uuid.New()); err != nil || reason != "" {
+		t.Fatalf("mergeOne: reason=%q err=%v", reason, err)
+	}
+	if e := wikiEntityOf(t, f.pool, f.ctx, loserArt); e != winner {
+		t.Errorf("article not repointed to winner: got %v", e)
+	}
+	if sb := wikiSupersededBy(t, f.pool, f.ctx, loserArt); sb != nil {
+		t.Errorf("repointed article wrongly superseded: %v", sb)
+	}
+}
+
+// Bug 1: un-merge clears the archive (superseded) flag — lossless round-trip.
+func TestRevertMerge_RestoresSupersededArticle(t *testing.T) {
+	f := newMergeFixture(t, "00000000000c")
+	cleanupWikiArticles(t, f)
+	winner := f.mkEntity(t, "哪吒", nil)
+	loser := f.mkEntity(t, "中壇元帥", nil)
+	_ = mkWikiArticle(t, f.pool, f.ctx, f.bookID, winner)
+	loserArt := mkWikiArticle(t, f.pool, f.ctx, f.bookID, loser)
+
+	jid, reason, err := f.srv.mergeOne(f.ctx, f.bookID, winner, f.kindID, loser, uuid.New())
+	if err != nil || reason != "" {
+		t.Fatalf("mergeOne: reason=%q err=%v", reason, err)
+	}
+	if sb := wikiSupersededBy(t, f.pool, f.ctx, loserArt); sb == nil {
+		t.Fatal("precondition: loser article should be superseded after merge")
+	}
+	if reason, err := f.srv.revertMergeCore(f.ctx, f.bookID, jid); err != nil || reason != "" {
+		t.Fatalf("revertMergeCore: reason=%q err=%v", reason, err)
+	}
+	if sb := wikiSupersededBy(t, f.pool, f.ctx, loserArt); sb != nil {
+		t.Errorf("un-merge did not clear superseded: %v", sb)
+	}
+	if del, _ := f.isSoftDeleted(t, loser); del {
+		t.Errorf("loser still soft-deleted after un-merge")
+	}
+}
+
+// Bug 2: the entity FK is RESTRICT — a raw entity delete with a live article must
+// FK-block (proving the silent ON DELETE CASCADE destruction is gone).
+func TestFK_WikiArticle_RestrictsEntityDelete(t *testing.T) {
+	f := newMergeFixture(t, "00000000000d")
+	cleanupWikiArticles(t, f)
+	ent := f.mkEntity(t, "妲己", nil)
+	_ = mkWikiArticle(t, f.pool, f.ctx, f.bookID, ent)
+	f.pool.Exec(f.ctx, `UPDATE glossary_entities SET deleted_at=now() WHERE entity_id=$1`, ent)
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM glossary_entities WHERE entity_id=$1`, ent); err == nil {
+		t.Fatal("entity delete with a wiki_article succeeded — FK is not RESTRICT (silent cascade still possible)")
+	}
+}
+
+// Bug 1 (AC1.2): GET on an archived (superseded) article redirects to the winner's
+// article, carrying redirected_from. HTTP path through verifyBookOwner (mocked).
+func TestGetWikiArticle_RedirectsSupersededToWinner(t *testing.T) {
+	f := newMergeFixture(t, "00000000000e")
+	cleanupWikiArticles(t, f)
+	owner := mockBookOwner(t, f)
+
+	winner := f.mkEntity(t, "周文王", nil)
+	loser := f.mkEntity(t, "姬昌", nil)
+	winnerArt := mkWikiArticle(t, f.pool, f.ctx, f.bookID, winner)
+	loserArt := mkWikiArticle(t, f.pool, f.ctx, f.bookID, loser)
+	if _, reason, err := f.srv.mergeOne(f.ctx, f.bookID, winner, f.kindID, loser, uuid.New()); err != nil || reason != "" {
+		t.Fatalf("mergeOne: reason=%q err=%v", reason, err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/glossary/books/"+f.bookID.String()+"/wiki/"+loserArt.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+makeExportToken(t, owner))
+	w := httptest.NewRecorder()
+	f.srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("getWikiArticle: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ArticleID      string `json:"article_id"`
+		EntityID       string `json:"entity_id"`
+		RedirectedFrom string `json:"redirected_from"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.ArticleID != winnerArt.String() {
+		t.Errorf("redirect served wrong article: got %s want winner %s", resp.ArticleID, winnerArt)
+	}
+	if resp.EntityID != winner.String() {
+		t.Errorf("redirect entity: got %s want winner %s", resp.EntityID, winner)
+	}
+	if resp.RedirectedFrom != loserArt.String() {
+		t.Errorf("redirected_from: got %s want loser %s", resp.RedirectedFrom, loserArt)
+	}
+}
+
+// Bug 2: user-delete of an article emits wiki.deleted (reason=user_deleted) atomically.
+func TestDeleteWikiArticle_EmitsWikiDeleted(t *testing.T) {
+	f := newMergeFixture(t, "00000000000f")
+	cleanupWikiArticles(t, f)
+	owner := mockBookOwner(t, f)
+
+	ent := f.mkEntity(t, "杨戬", nil)
+	art := mkWikiArticle(t, f.pool, f.ctx, f.bookID, ent)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/v1/glossary/books/"+f.bookID.String()+"/wiki/"+art.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+makeExportToken(t, owner))
+	w := httptest.NewRecorder()
+	f.srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("deleteWikiArticle: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	var nEvent, nArt int
+	f.pool.QueryRow(f.ctx, `SELECT count(*) FROM outbox_events WHERE event_type='wiki.deleted' AND payload->>'article_id'=$1`, art.String()).Scan(&nEvent)
+	if nEvent != 1 {
+		t.Errorf("wiki.deleted events = %d, want 1", nEvent)
+	}
+	f.pool.QueryRow(f.ctx, `SELECT count(*) FROM wiki_articles WHERE article_id=$1`, art.String()).Scan(&nArt)
+	if nArt != 0 {
+		t.Errorf("article not deleted (%d remain)", nArt)
+	}
+}

--- a/services/glossary-service/internal/api/wiki_handler.go
+++ b/services/glossary-service/internal/api/wiki_handler.go
@@ -41,6 +41,13 @@ type wikiArticleDetail struct {
 	SpoilerChapters []string        `json:"spoiler_chapters"`
 	Infobox         []attrValueResp `json:"infobox"`
 	CreatedAt       time.Time       `json:"created_at"`
+	// RedirectedFrom is set (to the requested article_id) when the requested
+	// article was archived by a merge (superseded) and this detail is the winner's
+	// article served in its place (Bug-1 redirect). Omitted on a normal fetch.
+	RedirectedFrom string `json:"redirected_from,omitempty"`
+	// SupersededBy is the winner entity of a merge that archived this article
+	// (Bug-1). Internal — drives the getWikiArticle redirect; not serialized.
+	SupersededBy *uuid.UUID `json:"-"`
 }
 
 type wikiRevisionListItem struct {
@@ -386,6 +393,29 @@ func (s *Server) getWikiArticle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug-1 redirect: if this article was archived by a merge (superseded_by set),
+	// serve the winner's article instead so links to a merged-away entity resolve.
+	// superseded_by comes from the same detail query — no extra round-trip on the
+	// common (non-superseded) path.
+	if detail.SupersededBy != nil {
+		var winnerArticleID uuid.UUID
+		if e := s.pool.QueryRow(r.Context(),
+			`SELECT article_id FROM wiki_articles WHERE entity_id=$1 AND book_id=$2 AND superseded_by_entity_id IS NULL`,
+			*detail.SupersededBy, bookID,
+		).Scan(&winnerArticleID); e == nil {
+			winner, werr := s.loadWikiArticleDetail(r, bookID, winnerArticleID)
+			if werr != nil {
+				slog.Error("getWikiArticle redirect", "error", werr)
+				writeError(w, http.StatusInternalServerError, "WIKI_INTERNAL", "internal error")
+				return
+			}
+			winner.RedirectedFrom = articleID.String()
+			writeJSON(w, http.StatusOK, winner)
+			return
+		}
+		// winner article missing → fall through and serve the archived article as-is.
+	}
+
 	writeJSON(w, http.StatusOK, detail)
 }
 
@@ -556,9 +586,40 @@ func (s *Server) deleteWikiArticle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.pool.Exec(r.Context(),
-		`DELETE FROM wiki_articles WHERE article_id=$1`, articleID); err != nil {
+	tx, err := s.pool.Begin(r.Context())
+	if err != nil {
+		slog.Error("deleteWikiArticle tx", "error", err)
+		writeError(w, http.StatusInternalServerError, "WIKI_INTERNAL", "internal error")
+		return
+	}
+	defer tx.Rollback(r.Context())
+
+	var delEntityID uuid.UUID
+	if err := tx.QueryRow(r.Context(),
+		`DELETE FROM wiki_articles WHERE article_id=$1 RETURNING entity_id`, articleID).Scan(&delEntityID); err != nil {
 		slog.Error("deleteWikiArticle", "error", err)
+		writeError(w, http.StatusInternalServerError, "WIKI_INTERNAL", "internal error")
+		return
+	}
+	// Bug-2: emit wiki.deleted in the SAME tx (transactional outbox) so delete + event
+	// are atomic — consistent with the kind-delete path; observable destruction.
+	exec := func(ctx context.Context, sql string, args ...any) error {
+		_, e := tx.Exec(ctx, sql, args...)
+		return e
+	}
+	if err := insertWikiDeletedOutboxEvent(r.Context(), exec, articleID, wikiDeletedPayload{
+		BookID:    bookID.String(),
+		ArticleID: articleID.String(),
+		EntityID:  delEntityID.String(),
+		Reason:    "user_deleted",
+		EmittedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		slog.Error("deleteWikiArticle emit wiki.deleted", "error", err)
+		writeError(w, http.StatusInternalServerError, "WIKI_INTERNAL", "internal error")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Error("deleteWikiArticle commit", "error", err)
 		writeError(w, http.StatusInternalServerError, "WIKI_INTERNAL", "internal error")
 		return
 	}
@@ -1110,7 +1171,7 @@ func (s *Server) loadWikiArticleDetail(r *http.Request, bookID, articleID uuid.U
 			ek.kind_id, ek.code, ek.name, ek.icon, ek.color,
 			wa.status, wa.template_code,
 			(SELECT COUNT(*) FROM wiki_revisions wr WHERE wr.article_id = wa.article_id) AS revision_count,
-			wa.updated_at, wa.body_json, wa.spoiler_chapters, wa.created_at
+			wa.updated_at, wa.body_json, wa.spoiler_chapters, wa.created_at, wa.superseded_by_entity_id
 		FROM wiki_articles wa
 		JOIN glossary_entities ge ON ge.entity_id = wa.entity_id
 		JOIN entity_kinds ek ON ek.kind_id = ge.kind_id
@@ -1128,7 +1189,7 @@ func (s *Server) loadWikiArticleDetail(r *http.Request, bookID, articleID uuid.U
 		&d.Kind.KindID, &d.Kind.Code, &d.Kind.Name, &d.Kind.Icon, &d.Kind.Color,
 		&d.Status, &d.TemplateCode,
 		&d.RevisionCount,
-		&d.UpdatedAt, &d.BodyJSON, &spoilerChapters, &d.CreatedAt,
+		&d.UpdatedAt, &d.BodyJSON, &spoilerChapters, &d.CreatedAt, &d.SupersededBy,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("loadWikiArticleDetail main: %w", err)

--- a/services/glossary-service/internal/migrate/migrate.go
+++ b/services/glossary-service/internal/migrate/migrate.go
@@ -559,7 +559,7 @@ func UpGenreGroups(ctx context.Context, pool *pgxpool.Pool) error {
 const wikiSQL = `
 CREATE TABLE IF NOT EXISTS wiki_articles (
   article_id       UUID PRIMARY KEY DEFAULT uuidv7(),
-  entity_id        UUID NOT NULL UNIQUE REFERENCES glossary_entities(entity_id) ON DELETE CASCADE,
+  entity_id        UUID NOT NULL UNIQUE REFERENCES glossary_entities(entity_id) ON DELETE RESTRICT,
   book_id          UUID NOT NULL,
   body_json        JSONB NOT NULL DEFAULT '{}',
   status           TEXT NOT NULL DEFAULT 'draft',
@@ -584,6 +584,38 @@ CREATE TABLE IF NOT EXISTS wiki_revisions (
   UNIQUE(article_id, version)
 );
 CREATE INDEX IF NOT EXISTS idx_wr_article ON wiki_revisions(article_id);
+
+-- Bug-1 fix: archive-redirect pointer for a loser article superseded by a merge
+-- winner. The loser's article is kept (revision-preserved) and points at the
+-- winner entity, never silently dropped (merge-spec AC4). NULL = live article.
+ALTER TABLE wiki_articles ADD COLUMN IF NOT EXISTS superseded_by_entity_id UUID DEFAULT NULL;
+CREATE INDEX IF NOT EXISTS idx_wa_superseded ON wiki_articles(superseded_by_entity_id)
+  WHERE superseded_by_entity_id IS NOT NULL;
+-- superseded_by points at the merge winner; ON DELETE SET NULL so a later hard-delete
+-- of the winner (e.g. via kind-delete) clears the redirect instead of dangling.
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'wiki_articles_superseded_by_fkey') THEN
+    ALTER TABLE wiki_articles ADD CONSTRAINT wiki_articles_superseded_by_fkey
+      FOREIGN KEY (superseded_by_entity_id) REFERENCES glossary_entities(entity_id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Bug-2 fix: wiki_articles is a product table — an entity delete must NOT silently
+-- cascade-destroy articles + revisions + suggestions. Swap the entity FK
+-- CASCADE -> RESTRICT (idempotent, constraint-name-agnostic so it survives a
+-- legacy auto-named constraint). kind-delete now removes articles explicitly,
+-- emits wiki.deleted, and surfaces a count instead of a silent cascade.
+DO $$
+DECLARE c text;
+BEGIN
+  SELECT conname INTO c FROM pg_constraint
+   WHERE conrelid = 'wiki_articles'::regclass AND contype = 'f'
+     AND confrelid = 'glossary_entities'::regclass;
+  IF c IS NOT NULL THEN EXECUTE format('ALTER TABLE wiki_articles DROP CONSTRAINT %I', c); END IF;
+END $$;
+ALTER TABLE wiki_articles
+  ADD CONSTRAINT wiki_articles_entity_id_fkey
+  FOREIGN KEY (entity_id) REFERENCES glossary_entities(entity_id) ON DELETE RESTRICT;
 `
 
 func UpWiki(ctx context.Context, pool *pgxpool.Pool) error {
@@ -1374,6 +1406,11 @@ CREATE TABLE IF NOT EXISTS merge_journal (
 );
 CREATE INDEX IF NOT EXISTS idx_merge_journal_book  ON merge_journal(book_id);
 CREATE INDEX IF NOT EXISTS idx_merge_journal_loser ON merge_journal(loser_entity_id);
+
+-- Bug-1 fix: when BOTH winner+loser have a wiki_article, the loser's is archived
+-- in place (superseded_by_entity_id := winner) rather than repointed. Record it
+-- so un-merge can clear the archive flag (symmetric with repointed_wiki_article_id).
+ALTER TABLE merge_journal ADD COLUMN IF NOT EXISTS superseded_wiki_article_id UUID DEFAULT NULL;
 `
 
 // UpEntityMerge creates the merge_journal table + merged_into_entity_id column


### PR DESCRIPTION
## Summary

Foundation for the wiki LLM-building feature, in two parts.

### 1. Data-loss bug fixes (shippable) - `775e6414`
Two pre-existing data-loss bugs in glossary-service, fixed *before* the wiki body becomes a valuable LLM-generated product:

- **Bug 1 - merge silently abandoned a loser''s `wiki_article`** when both winner+loser had one (violated merge-spec AC4; composed with Bug 2 into permanent loss). Now archived in place (`superseded_by_entity_id` -> winner, revision-preserved); `getWikiArticle` redirects a superseded article to the winner (`redirected_from`); `merge_journal.superseded_wiki_article_id` makes un-merge symmetric. Bodies are not auto-merged (deferred to the feature).
- **Bug 2 - kind-delete `ON DELETE CASCADE`** silently destroyed articles + revisions + suggestions. Entity FK `CASCADE -> RESTRICT`; kind-delete now deletes articles explicitly, returns a count (`200`, was a silent `204`), and emits a `wiki.deleted` outbox event (kind-delete + user-delete, atomic in-tx). `superseded_by` FK `ON DELETE SET NULL`.

### 2. LLM-building design (reference) - `78663910`
Spec v3 + 5-screen FE mockup. Wiki = a deferred-sync materialized view over a versioned knowledge base; home = knowledge-service; LLM contract = constrained Markdown -> IR -> deterministic TipTap; bounded multi-pass generation; change-control = capture / defer / decide (user-gated regen). **Design only - feature BUILD is not in this PR.**

## Test evidence
- /loom L (12-phase). DB-integration tests on real Postgres: 6 wiki-dataloss + existing merge/revert/deletekind suites green (no regression).
- /review-impl: 0 HIGH; 1 MED + 4 LOW + 1 COSMETIC all fixed + re-verified (redirect HTTP test via a reusable book-service mock harness; FK SET NULL; atomic emit; order-independent merge fixture).

## Notes
- Scope: glossary-service only (single service). The `wiki.deleted` event is emitted but not yet consumed.
- `deleteKind` response changed `204 -> 200 {deleted_wiki_articles}`; FE `apiJson` tolerates 200+body (verified).
- Next: wiki feature BUILD per spec v3 (prereq: move BookProfile -> book-service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)