### PR TITLE
chore(deps): upgrade syn to 3 (dp-kernel-macros)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.0",
  "trybuild",
  "uuid",
 ]
@@ -2192,7 +2192,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ pgvector = { version = "0.4", default-features = false, features = ["sqlx"] }
 prometheus = "0.14"
 
 # Cycle 17 (L4.B) — proc-macro toolkit for `#[derive(Aggregate)]`.
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 # trybuild is used by L4.B macros' tests to assert compile-error messages stay


### PR DESCRIPTION
Supersedes #105. `syn` is used directly only by `crates/dp-kernel-macros`; every other occurrence is transitive (keeps syn 2 — both majors coexist in the lock). Core syn API (DeriveInput, Data, Fields, Lit, Meta, Expr, LitStr, parse_macro_input, Error::new_spanned) is stable 2→3 ⇒ **zero code changes**.

**Verified under syn 3.0.0:** `cargo check -p dp-kernel-macros` (clean rebuild) clean · `cargo test -p dp-kernel-macros` 6/6 · `cargo check --workspace` 0 errors.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)