### PR TITLE
The 12-phase gate now runs from git, not from one agent's settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,20 +5,5 @@
       "Bash(bash ./scripts/workflow-gate.sh:*)",
       "Bash(python scripts/workflow-gate.py:*)"
     ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel)\" && if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE \"git commit\"; then bash ./scripts/workflow-gate.sh pre-commit; fi'",
-            "timeout": 30000,
-            "description": "Block git commit if VERIFY/POST-REVIEW/SESSION evidence is missing. The former ContextHub guardrail hooks (amaw-guardrail-gate.py, amaw-context-inject.py, amaw-pre-commit) were removed 2026-08-03 with the ContextHub MCP integration: they were fail-open wrappers around a server no agent ever actually called, so they added a per-Bash-call subprocess and a 75s commit timeout while gating nothing."
-          }
-        ]
-      }
-    ]
   }
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -316,3 +316,39 @@ if [ -n "$STAGED_TS" ]; then
     exit 1
   }
 fi
+
+# ── The 12-phase workflow gate — UNIVERSAL as of 2026-08-03 ────────────────────
+#
+# Until today this ran ONLY from `.claude/settings.json`'s PreToolUse hook, so it
+# fired when Claude Code issued `git commit` and for nobody else. That was fine
+# when Claude was effectively the only agent here. It stopped being fine the day
+# this became a five-agent repo: a contributor on Codex, Cursor or Copilot — and
+# any human typing `git commit` — walked straight past it, because none of them
+# read `.claude/settings.json`.
+#
+# A check whose scope reaches one of five callers is the "scope never reaches it"
+# shape from docs/standards/non-vacuity.md. Moved here, where git enforces it for
+# everyone regardless of what wrote the commit.
+#
+# IT DOES NOT BLOCK A CONTRIBUTOR WHO NEVER STARTED A RUN, and that is the property
+# that makes putting it here safe rather than hostile. `workflow-gate.py pre-commit`
+# fails OPEN when there is no `.workflow-state.json` — it prints "No workflow state
+# found. Proceeding without enforcement." and exits 0. It blocks only someone who
+# classified a task and then tried to commit mid-way. Verified through this whole
+# chain, both directions: no state -> exit 0; size classified, VERIFY not recorded
+# -> exit 1.
+#
+# That distinction is the whole design. An always-on phase gate would stop a
+# first-time contributor on their first commit, and the thing they would reach for
+# is `--no-verify`, which switches off db-safety, the provider gate and the secret
+# scan along with it. A gate that teaches people to disable the gates is worse than
+# no gate.
+#
+# It is LAST on purpose. The gates above find defects in the code; this one finds
+# a missing phase. Running it last means a blocked commit reports BOTH, instead of
+# sending you to fix the phase state and only then discovering a real finding.
+#
+# If it blocks you: record the evidence the phase actually has
+# (`python scripts/workflow-gate.py complete verify "<evidence>"`), or state the
+# skip (`... skip verify "<reason>"`). Do not reach for --no-verify.
+"$PY" "$ROOT/scripts/workflow-gate.py" pre-commit

--- a/agentic-workflow/README.md
+++ b/agentic-workflow/README.md
@@ -27,6 +27,16 @@ Prevents agents from skipping phases, undersizing tasks, and committing without 
 >
 > **AMAW v3.0 — opt-in.** First production run (Phase 14 model swap, 2026-05-15) caught 8 distinct findings across 6 sub-agent calls (~420K tokens), 5 of which were BLOCKs that would have been production bugs. Genuinely valuable for critical work; overkill for everyday tasks.
 
+> **Where the phase gate is enforced — this bundle differs from the parent repo on purpose.**
+> The bundle installs `scripts/workflow-gate.{sh,py}` plus a `.claude/settings.json` PreToolUse hook,
+> and that hook is its ONLY enforcement path: `install.sh` does not write a git hook into the target.
+> So in a bundle-installed repo the gate fires for Claude Code and for nobody else.
+>
+> LoreWeave itself moved the gate into `.githooks/pre-commit` on 2026-08-03, because it became a
+> five-agent repo and a check that reaches one caller in five is not a check. A target repo with
+> more than one agent should do the same: add `workflow-gate.py pre-commit` to its own pre-commit
+> hook and drop the PreToolUse copy, so git enforces it regardless of what wrote the commit.
+
 ## What's inside
 
 ```

--- a/docs/sessions/SESSION_HANDOFF.md
+++ b/docs/sessions/SESSION_HANDOFF.md
@@ -174,6 +174,16 @@ because `core.hooksPath` was unset. See NEXT-5.
    cause. Set it: `git config core.hooksPath .githooks`. **Do this on any checkout of this repo**;
    `CONTRIBUTING.md` says so and it is easy to skip.
 
+   Enabling it exposed a second gap, now closed: the **12-phase gate lived only in
+   `.claude/settings.json`**, so it fired when Claude Code issued `git commit` and for nobody else —
+   one caller in five, on a repo that became five-agent the same day. Moved into
+   `.githooks/pre-commit` (last in the chain, so a blocked commit reports code findings *and* the
+   missing phase). **It does not block a contributor who never started a run:** `workflow-gate.py
+   pre-commit` fails open with "No workflow state found" when there is no `.workflow-state.json`.
+   Measured both ways through the real chain — no state → exit 0; size classified with VERIFY
+   unrecorded → exit 1. The duplicate PreToolUse copy is gone; the bundle keeps its own, because
+   `install.sh` writes no git hook into a target repo.
+
 ### Not fixed, and not tracked anywhere else
 
 - **Book search is broken for Vietnamese diacritics** on a Vietnamese-first product: `eval` → 19


### PR DESCRIPTION
It lived only in `.claude/settings.json`, so it fired when Claude Code issued `git commit` and **for nobody else**. Fine while Claude was effectively the only agent here; not fine the day this became a five-agent repo — Codex, Cursor and Copilot never read that file, and neither does a human typing `git commit`. One caller in five is the *"scope never reaches it"* shape from `docs/standards/non-vacuity.md`.

## It does not block contributors, and that is the whole design

I initially told @letuhao this change would block every commit until the phases were walked. **That was wrong, and measurement bounced it back.** `workflow-gate.py pre-commit` already fails open:

| State | `sh .githooks/pre-commit` |
|---|---|
| No `.workflow-state.json` — a contributor who never started a run | **exit 0** — *"No workflow state found. Proceeding without enforcement."* |
| `size` classified, VERIFY unrecorded — someone mid-run | **exit 1** — `COMMIT BLOCKED: Phase 6 VERIFY not done` |

Measured with the real exit code of the whole chain, both directions.

An always-on phase gate would stop a first-time contributor on their first commit, and what they would reach for is `--no-verify` — which switches off db-safety, the provider gate and the secret scan along with it. **A gate that teaches people to disable the gates is worse than no gate.**

## Placement

**Last in the chain, on purpose.** A blocked commit then reports *both* the code findings and the missing phase, instead of sending you to fix phase state and only afterwards discovering a real defect.

## The duplicate is gone

`.claude/settings.json`'s PreToolUse copy is removed — git is now the single enforcement point. Keeping a second copy that only one of five agents reads is the same two-mechanisms-for-one-job pattern cleaned up elsewhere today.

`agentic-workflow/` **keeps** its copy and now says why: `install.sh` writes no git hook into its target, so for a bundle-installed repo that hook is the only enforcement path there is. The README tells such a repo to move it once it has more than one agent.

## Verification

- Full hook chain measured both directions (above)
- This PR's own commit went **through** the new gate — `OK: Pre-commit checks passed (verify + post-review + session completed)`
- `gate-wiring-gate` OK (86 gates), `.claude/settings.json` still valid JSON
- Phases walked for real: VERIFY carries the measured evidence, POST-REVIEW carries the human approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)